### PR TITLE
feat(demo): show Stop button immediately after Generate click

### DIFF
--- a/demo/gradio_demo.py
+++ b/demo/gradio_demo.py
@@ -992,6 +992,11 @@ Or paste text directly and it will auto-assign speakers.""",
             inputs=[],
             outputs=[audio_output, complete_audio_output],
             queue=False
+        ).then(  # Immediate UI update to hide Generate, show Stop (non-queued)
+            fn=lambda: (gr.update(visible=False), gr.update(visible=True)),
+            inputs=[],
+            outputs=[generate_btn, stop_btn],
+            queue=False
         ).then(
             fn=generate_podcast_wrapper,
             inputs=[num_speakers, script_input] + speaker_selections + [cfg_scale],


### PR DESCRIPTION
**TL;DR:**  
Stop button set to appear immediately after clicking Generate, even if the job is queued due to demand. Users can cancel anytime. One minimal UI fix, no impact on backend or streaming logic.

### Summary

The Stop button previously appeared only after the backend generation job actually started, leaving users with no cancel affordance while a request sat waiting in the demo queue. 
This immediate visual feedback is particularly important for this new release, as demo queues are capped at 20, and it helps users of all learning levels understand the status of their request. 
This PR makes the Stop button visible immediately after clicking **Generate Podcast**.

### Change
Adds a single non-queued `.then` step in the click event chain:

```python
).then(
    fn=lambda: (gr.update(visible=False), gr.update(visible=True)),
    inputs=[],
    outputs=[generate_btn, stop_btn],
    queue=False
)
```

This hides the Generate button and shows the Stop button instantly, before the queued job begins processing.

### Rationale
- Improves UX: users can cancel even while waiting in queue.
- Minimal change (1 chained step, no logic refactor).
- No JS or DOM hacks; uses native Gradio event chaining.
- Zero impact on generation or streaming code.

### Acceptance Criteria
- Generate → Stop appears immediately (even under queue delay).
- Stop → cancels and buttons revert (existing logic unchanged).
- Normal completion → Stop hides; Generate reappears.
- No regression in streaming audio or final output behavior.

### Testing
Manual verification:
1. Start generation with queue delay: Stop shows instantly.
2. Cancel before audio starts: cancellation works; buttons revert.
3. Let generation finish: buttons revert correctly and final audio visible.


### Notes
This is intentionally the smallest viable UX fix. Further enhancements (queue position display, tooltip) can be separate PRs.
