### PR TITLE
Specifically reference newer llvmlite and numba dependencies for uv

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,8 @@ dependencies = [
     "torch",
     "accelerate==1.6.0",
     "transformers==4.51.3", # we develop this project on transformers==4.51.3, later version may not be compatible
+    "llvmlite>=0.40.0",
+    "numba>=0.57.0",
     "diffusers",
     "tqdm",
     "numpy",


### PR DESCRIPTION
llvmlite is trying to build an old version that creates a dependency chain issue when installing with uv:
```
  help: `llvmlite` (v0.36.0) was included because `vibevoice` (v0.0.1) depends on `librosa` (v0.11.0) which
        depends on `numba` (v0.53.1) which depends on `llvmlite`
```

pinning these dependencies on newer versions forces it to resolve and shouldn't have any downsides.