### PR TITLE
update requires-python = '>=3.9'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 description = "A model for speech generation with an AR + diffusion architecture."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Python :: 3",
     # "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
$ uv sync
warning: `VIRTUAL_ENV=/home/microsoft/Documents/mycode/index-tts/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
Using CPython 3.12.3 interpreter at: /usr/bin/python3
Creating virtual environment at: .venv
⠇ ml-collections==1.1.0                                                                                                                                                                                                                                      
⠋ ml-collections==1.1.0                                                                                                                                                                                                                                      
  × No solution found when resolving dependencies for split (markers: python_full_version == '3.8.*'):
  ╰─▶ Because the requested Python version (>=3.8) does not satisfy Python>=3.9.0 and accelerate==1.6.0 depends on Python>=3.9.0, we can conclude that accelerate==1.6.0 cannot be used.
      And because your project depends on accelerate==1.6.0, we can conclude that your project's requirements are unsatisfiable.

      hint: The `requires-python` value (>=3.8) includes Python versions that are not supported by your dependencies (e.g., accelerate==1.6.0 only supports >=3.9.0). Consider using a more restrictive `requires-python` value (like >=3.9.0).

      hint: While the active Python version is 3.12, the resolution failed for other Python versions supported by your project. Consider limiting your project's supported Python versions using `requires-python`.