### PR TITLE
DirectML: force boolean attention_mask before HF model calls

### DIFF
--- a/vibevoice/modular/modeling_vibevoice.py
+++ b/vibevoice/modular/modeling_vibevoice.py
@@ -23,6 +23,14 @@ from vibevoice.schedule.dpm_solver import DPMSolverMultistepScheduler
 
 from .configuration_vibevoice import VibeVoiceConfig
 
+# --- DirectML: ensure boolean attention mask (avoids uint8 overflow in masked_fill) ---
+def _ensure_bool_attn_mask(mask):
+    if mask is None:
+        return None
+    return mask if mask.dtype is torch.bool else (mask != 0)
+# --------------------------------------------------------------------------------------
+
+
 
 logger = logging.get_logger(__name__)
 
@@ -183,6 +191,8 @@ class VibeVoiceModel(VibeVoicePreTrainedModel):
         
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
         
+        attention_mask = _ensure_bool_attn_mask(attention_mask)
+
         # Forward through language model
         outputs = self.language_model(
             input_ids=input_ids,


### PR DESCRIPTION
Follow-up to #49 (separate from #51).

On torch-directml, uint8 attention masks can overflow when Transformers (Qwen2)
applies masked_fill(-inf) during causal mask prep. Fix: ensure boolean attention_mask
immediately before calling self.language_model(...). No behavior change on CUDA/CPU.
