### PR TITLE
minimum mps support

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,25 @@ cd VibeVoice/
 pip install -e .
 ```
 
+### Device Support
+
+VibeVoice automatically detects and uses the best available device:
+- **CUDA** (NVIDIA GPUs) - preferred when available
+- **MPS** (Apple Silicon) - automatically used on macOS with Apple Silicon
+- **CPU** - fallback when no GPU acceleration is available
+
+No additional configuration is needed. The demos will automatically use the optimal device and settings.
+
+**For optimal CUDA performance**, install with flash attention:
+```bash
+pip install -e .[cuda]
+```
+
+**For MPS users**: Ensure you have PyTorch 2.1+ on macOS with Apple Silicon. If you encounter unsupported operations, set:
+```bash
+export PYTORCH_ENABLE_MPS_FALLBACK=1
+```
+
 ## Usages
 
 ### 🚨 Tips

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,10 @@ dependencies = [
     "aiortc"
 ]
 
+[project.optional-dependencies]
+cuda = [
+    "flash-attn>=2.5.0"
+]
 
 [project.urls]
 "Homepage" = "https://github.com/microsoft/VibeVoice"

--- a/vibevoice/utils/devices.py
+++ b/vibevoice/utils/devices.py
@@ -1,0 +1,67 @@
+"""Minimal device detection utilities for VibeVoice."""
+
+import torch
+
+
+def detect_device(prefer_cuda: bool = True) -> torch.device:
+    """Detect the optimal device for inference.
+    
+    Args:
+        prefer_cuda: If True, prefer CUDA over MPS when both are available.
+                    This preserves default behavior on machines with NVIDIA GPUs.
+    
+    Returns:
+        torch.device: The detected device (cuda, mps, or cpu)
+    """
+    # Prefer CUDA if available (preserves default behavior on machines with NVIDIA GPUs)
+    if prefer_cuda and torch.cuda.is_available():
+        return torch.device("cuda")
+
+    # Use MPS if available (Apple Silicon)
+    has_mps = getattr(torch.backends, "mps", None) is not None
+    if has_mps:
+        try:
+            if torch.backends.mps.is_available():
+                return torch.device("mps")
+        except Exception:
+            pass
+
+    # Fallback: CPU
+    return torch.device("cpu")
+
+
+def recommended_dtype_for(device: torch.device) -> torch.dtype:
+    """Get recommended dtype for a given device.
+    
+    Args:
+        device: The target device
+        
+    Returns:
+        torch.dtype: Recommended dtype for the device
+    """
+    # Conservative, stable defaults
+    if device.type == "cuda":
+        return torch.bfloat16
+    if device.type == "mps":
+        return torch.float16  # More stable than bfloat16 on MPS
+    return torch.float32
+
+
+def get_attention_implementation(device: torch.device) -> str:
+    """Get the recommended attention implementation for a device.
+    
+    Args:
+        device: The target device
+        
+    Returns:
+        str: Either "flash_attention_2" or "sdpa"
+    """
+    if device.type == "cuda":
+        try:
+            import flash_attn
+            return "flash_attention_2"
+        except ImportError:
+            return "sdpa"
+    else:
+        # MPS and CPU use SDPA
+        return "sdpa"


### PR DESCRIPTION
the quick-and-dirty version  

This lets VibeVoice run on Apple Silicon (without CUDA). It faithfully does the bare minimum: detects the Mac’s MPS backend, picks a safe dtype/attention combo, and starts the demo. Everything else (CLI flags, bfloat16, tests, diagnostics) was cut so the diff stays small and readable.

### How it works 
- Essentially the structure is the same, but less robust. 
- A helper (`vibevoice/utils/devices.py`) chooses the best device/attention stack.  
- `gradio_demo.py` and `inference_from_file.py` now call that helper; no `--device` or `--dtype` flags remain.  
- `flash-attn` is now an optional `[cuda]` extra, so pip install succeeds on macOS.  
- If Flash-Attention isn’t found, the code quietly falls back to SDPA.  

### What you lose  
- No runtime switches: power users can’t override the auto-detected settings.  
- MPS is locked to float16; faster bfloat16 support is gone.  
- Device-loading code is duplicated in both demo scripts.  
- No tests, no benchmark script, no diagnostic tool, no automatic env-vars.  
- The whole-repo linting fixes that accidentally rode along in the bigger PR (and maybe killed it) are also gone.

### Quick test  
Apple Silicon  
```
python demo/inference_from_file.py --model_path …
# should print “Device: mps” and emit audio
```

CUDA w/ flash-attn  
```
pip install -e .[cuda]
python demo/inference_from_file.py …
# should print “Attention: flash_attention_2”
```

CUDA w/o flash-attn  
```
pip uninstall flash-attn
python demo/inference_from_file.py …
# should fall back to SDPA
```

My 2 cents: This branch gives VibeVoice mps support without the end-user control features, etc, and leaves the chore of keeping it maintainable til another day. The full-featured PR (#38) is still around if you want the polished, future-proof solution.