### PR TITLE
feat: add GPU architecture detection for flash attention compatibility

### DIFF
--- a/demo/gradio_demo.py
+++ b/demo/gradio_demo.py
@@ -63,7 +63,19 @@ class VibeVoiceDemo:
             attn_impl_primary = "sdpa"
         elif self.device == "cuda":
             load_dtype = torch.bfloat16
-            attn_impl_primary = "flash_attention_2"
+            # Check GPU architecture for flash attention compatibility
+            if torch.cuda.is_available():
+                gpu_arch = torch.cuda.get_device_capability(0)
+                # Ampere (8.0+) and newer support flash_attention_2
+                # Turing (7.5) and older should use flash_attention
+                if gpu_arch[0] >= 8:  # Ampere and newer
+                    attn_impl_primary = "flash_attention_2"
+                    print(f"GPU architecture {gpu_arch} detected: using flash_attention_2")
+                else:  # Turing and older
+                    attn_impl_primary = "flash_attention"
+                    print(f"GPU architecture {gpu_arch} detected: using flash_attention (older GPU)")
+            else:
+                attn_impl_primary = "flash_attention_2"  # fallback default
         else:
             load_dtype = torch.float32
             attn_impl_primary = "sdpa"
@@ -93,7 +105,7 @@ class VibeVoiceDemo:
                     attn_implementation=attn_impl_primary,
                 )
         except Exception as e:
-            if attn_impl_primary == 'flash_attention_2':
+            if attn_impl_primary in ['flash_attention_2', 'flash_attention']:
                 print(f"[ERROR] : {type(e).__name__}: {e}")
                 print(traceback.format_exc())
                 fallback_attn = "sdpa"


### PR DESCRIPTION
Automatically detect NVIDIA GPU architecture and select appropriate flash attention implementation:
- Ampere (8.0+) and newer GPUs use flash_attention_2
- Turing (7.5) and older GPUs use flash_attention for compatibility
- Updated fallback mechanism to handle both flash attention variants
- Added informative logging for selected attention implementation