### PR TITLE
Fix: Remove unnecessary Path() conversion for HuggingFace model IDs

### DIFF
--- a/demo/web/app.py
+++ b/demo/web/app.py
@@ -45,7 +45,8 @@ class StreamingTTSService:
         device: str = "cuda",
         inference_steps: int = 5,
     ) -> None:
-        self.model_path = Path(model_path)
+        # Keep model_path as string for HuggingFace repo IDs (Path() converts / to \ on Windows)
+        self.model_path = model_path
         self.inference_steps = inference_steps
         self.sample_rate = SAMPLE_RATE
 
@@ -66,7 +67,7 @@ class StreamingTTSService:
 
     def load(self) -> None:
         print(f"[startup] Loading processor from {self.model_path}")
-        self.processor = VibeVoiceStreamingProcessor.from_pretrained(str(self.model_path))
+        self.processor = VibeVoiceStreamingProcessor.from_pretrained(self.model_path)
 
         
         # Decide dtype & attention
@@ -86,7 +87,7 @@ class StreamingTTSService:
         # Load model
         try:
             self.model = VibeVoiceStreamingForConditionalGenerationInference.from_pretrained(
-                str(self.model_path),
+                self.model_path,
                 torch_dtype=load_dtype,
                 device_map=device_map,
                 attn_implementation=attn_impl_primary,
@@ -99,7 +100,7 @@ class StreamingTTSService:
                 print("Error loading the model. Trying to use SDPA. However, note that only flash_attention_2 has been fully tested, and using SDPA may result in lower audio quality.")
                 
                 self.model = VibeVoiceStreamingForConditionalGenerationInference.from_pretrained(
-                    str(self.model_path),
+                    self.model_path,
                     torch_dtype=load_dtype,
                     device_map=self.device,
                     attn_implementation='sdpa',


### PR DESCRIPTION
## Summary

This PR fixes a bug where HuggingFace model IDs fail to load on Windows.

### The Problem

In `demo/web/app.py`, the `model_path` parameter was being converted to a `Path` object:

```python
self.model_path = Path(model_path)
```

Then converted back to string for `from_pretrained()` calls:

```python
self.processor = VibeVoiceStreamingProcessor.from_pretrained(str(self.model_path))
```

On Windows, `Path()` converts forward slashes to backslashes, so:
- Input: `"microsoft/VibeVoice-Realtime-0.5B"`
- After `Path()`: `WindowsPath('microsoft/VibeVoice-Realtime-0.5B')`
- After `str()`: `"microsoft\VibeVoice-Realtime-0.5B"`

This breaks HuggingFace Hub lookups.

### The Fix

Keep `model_path` as a string since `from_pretrained()` accepts strings directly. This:
- **No behavior change on Linux/macOS** (forward slashes remain unchanged)
- **Fixes Windows compatibility** for HuggingFace repo IDs
- **Removes redundant** `str()` conversions

### Changes

- `demo/web/app.py`: Remove `Path()` wrapping and `str()` conversions for `model_path`

## Test Plan

- [x] Tested on Windows 11 with `microsoft/VibeVoice-Realtime-0.5B`
- [x] Model loads correctly and generates audio