### PR TITLE
feat: add __init__.py files to enable module imports

### DIFF
--- a/vibevoice/__init__.py
+++ b/vibevoice/__init__.py
@@ -1,0 +1,16 @@
+# vibevoice/__init__.py
+from vibevoice.modular import (
+    VibeVoiceStreamingForConditionalGenerationInference,
+    VibeVoiceStreamingConfig,
+)
+from vibevoice.processor import (
+    VibeVoiceStreamingProcessor,
+    VibeVoiceTokenizerProcessor,
+)
+
+__all__ = [
+    "VibeVoiceStreamingForConditionalGenerationInference",
+    "VibeVoiceStreamingConfig",
+    "VibeVoiceStreamingProcessor",
+    "VibeVoiceTokenizerProcessor",
+]

--- a/vibevoice/modular/__init__.py
+++ b/vibevoice/modular/__init__.py
@@ -1,0 +1,14 @@
+# vibevoice/modular/__init__.py
+from .modeling_vibevoice_streaming_inference import VibeVoiceStreamingForConditionalGenerationInference
+from .configuration_vibevoice_streaming import VibeVoiceStreamingConfig
+from .modeling_vibevoice_streaming import VibeVoiceStreamingModel, VibeVoiceStreamingPreTrainedModel
+from .streamer import AudioStreamer, AsyncAudioStreamer
+
+__all__ = [
+    "VibeVoiceStreamingForConditionalGenerationInference",
+    "VibeVoiceStreamingConfig",
+    "VibeVoiceStreamingModel",
+    "VibeVoiceStreamingPreTrainedModel",
+    "AudioStreamer",
+    "AsyncAudioStreamer",
+]

--- a/vibevoice/processor/__init__.py
+++ b/vibevoice/processor/__init__.py
@@ -1,0 +1,11 @@
+# vibevoice/processor/__init__.py
+from .vibevoice_processor import VibeVoiceProcessor
+from .vibevoice_streaming_processor import VibeVoiceStreamingProcessor
+from .vibevoice_tokenizer_processor import VibeVoiceTokenizerProcessor, AudioNormalizer
+
+__all__ = [
+    "VibeVoiceProcessor",
+    "VibeVoiceStreamingProcessor",
+    "VibeVoiceTokenizerProcessor",
+    "AudioNormalizer",
+]


### PR DESCRIPTION
Add `__init__.py` files to the `vibevoice/modular` and `vibevoice/processor` directories with proper `__all__` exports (or star exports) for the main public classes.

This enables clean user-facing imports after installation:

```python
from vibevoice import VibeVoiceStreamingForConditionalGenerationInference
from vibevoice.modular import VibeVoiceStreamingConfig
from vibevoice.processor import VibeVoiceStreamingProcessor
```

Also fixes import errors when installing in editable mode with `pip install -e .`.

Before this change, attempting the above imports would raise `ModuleNotFoundError` or `ImportError`.