### PR TITLE
fix: issues in error handling

### DIFF
--- a/demo/web/app.py
+++ b/demo/web/app.py
@@ -467,6 +467,11 @@ async def websocket_stream(ws: WebSocket) -> None:
             print("Client disconnected (WebSocketDisconnect)")
             enqueue_log("client_disconnected")
             stop_signal.set()
+        except Exception as e:
+            print(f"Error in websocket stream: {e}")
+            traceback.print_exc()
+            enqueue_log("backend_error", message=str(e))
+            stop_signal.set()
         finally:
             stop_signal.set()
             enqueue_log("backend_stream_complete")
@@ -483,8 +488,11 @@ async def websocket_stream(ws: WebSocket) -> None:
                     log_queue.get_nowait()
                 except Empty:
                     break
-            if ws.client_state == WebSocketState.CONNECTED:
-                await ws.close()
+            try:
+                if ws.client_state == WebSocketState.CONNECTED:
+                    await ws.close()
+            except Exception as e:
+                print(f"Error closing websocket: {e}")
             print("WS handler exit")
     finally:
         if acquired:


### PR DESCRIPTION

---

## 🔄 Pull Request (Concise)

```markdown
# fix: WebSocket error handling causes crashes and log pollution

## 📋 Summary
Fixes critical error handling in WebSocket streaming that causes crashes on normal disconnects and silent failures on errors.

## 🐛 Problems Fixed

**Issue 1: RuntimeError on every disconnect**
- Users stop playback → server logs `RuntimeError: Cannot call "send" once...`
- Fix: Wrap `ws.close()` in try-catch

**Issue 2: Unhandled exceptions**
- Only catches `WebSocketDisconnect`, not OOM/model errors
- Silent failures, no user feedback, resources leak
- Fix: Add generic exception handler

## 🔧 Changes

# 1. Safe WebSocket close
try:
    if ws.client_state == WebSocketState.CONNECTED:
        await ws.close()
except Exception as e:
    print(f"Error closing websocket: {e}")

# 2. Catch all streaming errors
except Exception as e:
    print(f"Error in websocket stream: {e}")
    traceback.print_exc()
    enqueue_log("backend_error", message=str(e))
    stop_signal.set()