### PR TITLE
Add news about VibeVoice ASR Transformers integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@
 
 <h3>📰 News</h3>
 
-<strong>2026-01-21: 📣 We open-sourced <a href="docs/vibevoice-asr.md"><strong>VibeVoice-ASR</strong></a>, a unified speech-to-text model designed to handle 60-minute long-form audio in a single pass, generating structured transcriptions containing Who (Speaker), When (Timestamps), and What (Content), with support for User-Customized Context. Try it in [Playground](https://aka.ms/vibevoice-asr)</strong>. 
+<strong>2026-03-06: 🚀 VibeVoice ASR is now part of a <a href="https://github.com/huggingface/transformers/releases/tag/v5.3.0">Transformers release</a>! You can now use our speech recognition model directly through the Hugging Face Transformers library for seamless integration into your projects.</strong>
+
+<strong>2026-01-21: 📣 We open-sourced <a href="docs/vibevoice-asr.md"><strong>VibeVoice-ASR</strong></a>, a unified speech-to-text model designed to handle 60-minute long-form audio in a single pass, generating structured transcriptions containing Who (Speaker), When (Timestamps), and What (Content), with support for User-Customized Context. Try it in [Playground](https://aka.ms/vibevoice-asr)</strong>.
 - ⭐️ VibeVoice-ASR is natively multilingual, supporting over 50 languages — check the [supported languages](docs/vibevoice-asr.md#language-distribution) for details.
 - 🔥 The VibeVoice-ASR [finetuning code](finetuning-asr/README.md) is now available!
 - ⚡️ **vLLM inference** is now supported for faster inference; see [vllm-asr](docs/vibevoice-vllm-asr.md) for more details.


### PR DESCRIPTION
## Summary
- Added announcement that VibeVoice ASR is now part of Transformers v5.3.0 release
- Added link to the official Hugging Face Transformers release page
- Positioned as the latest news item with today's date (2026-03-06)

## Changes
- Updated README.md News section with new entry about Transformers integration
- Maintains chronological order of news items

## Test plan
- [x] Verify README.md renders correctly with new news entry
- [x] Confirm link to Transformers release works properly
- [x] Check formatting consistency with existing news items

🤖 Generated with [Claude Code](https://claude.com/claude-code)