### PR TITLE
Upgrade minimum Python requirement to 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 description = "Open-Source Frontier Voice AI."
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
     # "License :: OSI Approved :: MIT License",


### PR DESCRIPTION

### Summary
This PR updates the requires-python specification in pyproject.toml from >=3.9 to >=3.10.
### The Problem
The project was failing to build using the uv package manager due to a dependency version mismatch. Specifically, gradio==5.35.0 requires Python 3.10 or higher, which conflicted with the project's metadata claiming support for Python 3.9.
### Console error log:

x No solution found when resolving dependencies for split
  | (python_full_version == '3.9.*'):
  `-> Because the requested Python version (>=3.9) does not satisfy
      Python>=3.10 and gradio==5.35.0 depends on Python>=3.10, we can
      conclude that gradio==5.35.0 cannot be used.

### Changes

* Updated requires-python in pyproject.toml to >=3.10.
* This ensures that uv and other installers correctly resolve dependencies for the current Gradio version used in the project.

### Testing
Verified that the environment now resolves correctly with the active Python 3.10 interpreter, allowing the Gradio demo to start without resolution errors.

