### PR TITLE
fix: Windows compatibility - bypass missing 'pwd' module for Torch

### DIFF
--- a/demo/vibevoice_asr_gradio_demo.py
+++ b/demo/vibevoice_asr_gradio_demo.py
@@ -21,6 +21,12 @@ import traceback
 import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
+    # Error correction 'pwd' for Windows
+if sys.platform == 'win32':
+    os.environ['USER'] = os.environ.get('USERNAME', 'user')
+    os.environ['TORCHINDUCTOR_CACHE_DIR'] = os.path.join(os.environ.get('TEMP', '.'), 'torch_cache')
+
+
 # Import TextIteratorStreamer for streaming generation
 from transformers import TextIteratorStreamer, StoppingCriteria, StoppingCriteriaList
 


### PR DESCRIPTION
### Summary
This PR fixes a critical crash on Windows where the application fails to start due to ModuleNotFoundError: No module named 'pwd'.

### The Problem
The error occurs when torch (specifically torch._inductor) attempts to determine the user's home directory for caching using Unix-only modules. On Windows, this leads to the following traceback:

text :
File "getpass.py", line 168, in getuser
    import pwd
ModuleNotFoundError: No module named 'pwd'

### The Solution
I have added a platform-check at the beginning of demo/gradio_demo.py to:
Manually define the USER environment variable.
Explicitly set TORCHINDUCTOR_CACHE_DIR to the system's temp folder.
This allows the script to initialize correctly on Windows systems without requiring the user to manually set up environment variables in their shell.

### Testing
Verified on Windows 10/11: the Gradio interface now launches successfully on port 7860 as expected.