### PR TITLE
docs: add security note for public ASR demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ For more information, demos, and examples, please visit our [Project Page](https
 
 [📖 Documentation](docs/vibevoice-asr.md) | [🤗 Hugging Face](https://huggingface.co/microsoft/VibeVoice-ASR) | [🎮 Playground](https://aka.ms/vibevoice-asr) | [🛠️ Finetuning](finetuning-asr/README.md) |  [📊 Paper](docs/VibeVoice-ASR-Report.pdf)
 
+> Security note: if you self-host the ASR Gradio demo with `--share` or another public tunnel, treat uploaded media and local model artifacts as untrusted inputs.
+
 
 <p align="center">
   <img src="Figures/DER.jpg" alt="DER" width="50%"><br>

--- a/docs/vibevoice-asr.md
+++ b/docs/vibevoice-asr.md
@@ -81,6 +81,8 @@ apt update && apt install ffmpeg -y # for demo
 python demo/vibevoice_asr_gradio_demo.py --model_path microsoft/VibeVoice-ASR --share
 ```
 
+> Security note: `--share` creates a public Gradio link. Only use it for trusted traffic, and only load trusted local voice preset files and model artifacts.
+
 ### Usage 2: Inference from files directly
 ```bash
 python demo/vibevoice_asr_inference_from_file.py --model_path microsoft/VibeVoice-ASR --audio_files [add a audio path here] 
@@ -128,6 +130,5 @@ LoRA (Low-Rank Adaptation) fine-tuning is supported. See [Finetuning](../finetun
 ## 📄 License
 
 This project is licensed under the [MIT License](../LICENSE).
-
 
 


### PR DESCRIPTION
## Summary

Add a short security note to the ASR docs for public demo deployments.

This PR is intentionally limited to documentation. It is meant to complement #263 rather than overlap with its runtime hardening changes.

## Changes

- Add a warning in `docs/vibevoice-asr.md` next to the `--share` example
- Add a matching note in `README.md` near the ASR demo links

## Why

The current docs make it easy to copy-paste a public Gradio demo launch command, but they do not call out that public uploads and local model artifacts should be treated as untrusted inputs.

This note is meant to reduce accidental unsafe deployments without changing runtime behavior.

## Verification

- Reviewed rendered markdown locally
- Confirmed this PR stays docs-only and does not overlap with the runtime hardening work in #263
