### PR TITLE
fix: use torch_dtype instead of dtype in from_pretrained calls

### DIFF
--- a/demo/vibevoice_asr_gradio_demo.py
+++ b/demo/vibevoice_asr_gradio_demo.py
@@ -72,7 +72,7 @@ class VibeVoiceASRInference:
         print(f"Using attention implementation: {attn_implementation}")
         self.model = VibeVoiceASRForConditionalGeneration.from_pretrained(
             model_path,
-            dtype=dtype,
+            torch_dtype=dtype,
             device_map=device if device == "auto" else None,
             attn_implementation=attn_implementation,
             trust_remote_code=True

--- a/demo/vibevoice_asr_inference_from_file.py
+++ b/demo/vibevoice_asr_inference_from_file.py
@@ -53,7 +53,7 @@ class VibeVoiceASRBatchInference:
         print(f"Using attention implementation: {attn_implementation}")
         self.model = VibeVoiceASRForConditionalGeneration.from_pretrained(
             model_path,
-            dtype=dtype,
+            torch_dtype=dtype,
             device_map=device if device == "auto" else None,
             attn_implementation=attn_implementation,
             trust_remote_code=True

--- a/finetuning-asr/inference_lora.py
+++ b/finetuning-asr/inference_lora.py
@@ -49,7 +49,7 @@ def load_lora_model(
     # Load base model
     model = VibeVoiceASRForConditionalGeneration.from_pretrained(
         base_model_path,
-        dtype=dtype,
+        torch_dtype=dtype,
         device_map=device if device == "auto" else None,
         attn_implementation="flash_attention_2",
         trust_remote_code=True,

--- a/finetuning-asr/lora_finetune.py
+++ b/finetuning-asr/lora_finetune.py
@@ -407,7 +407,7 @@ def setup_model_for_training(
     # Load model
     model = VibeVoiceASRForConditionalGeneration.from_pretrained(
         model_path,
-        dtype=dtype,
+        torch_dtype=dtype,
         device_map=device if device == "auto" else None,
         attn_implementation="flash_attention_2",
         trust_remote_code=True,


### PR DESCRIPTION
Fixes #219

HuggingFace `from_pretrained()` expects `torch_dtype` as the parameter name, not `dtype`. Passing `dtype=` causes `TypeError: Object of type dtype is not JSON serializable` because PyTorch dtype objects are not JSON-serializable and the unexpected kwarg gets passed through to config serialization.

**Changed in 4 files:**
- `demo/vibevoice_asr_gradio_demo.py`
- `demo/vibevoice_asr_inference_from_file.py`
- `finetuning-asr/inference_lora.py`
- `finetuning-asr/lora_finetune.py`

All `dtype=dtype` → `torch_dtype=dtype` in `from_pretrained()` calls. Other uses of `dtype` (constructor params, `torch.tensor()` calls) are correct and untouched.