### PR TITLE
feat: add optional Traditional Chinese output via OpenCC post-processing

### DIFF
--- a/vibevoice/processor/vibevoice_asr_processor.py
+++ b/vibevoice/processor/vibevoice_asr_processor.py
@@ -66,13 +66,20 @@ class VibeVoiceASRProcessor:
         else:
             self.audio_normalizer = None
 
-        self.output_script = output_script
+        self.output_script = self._normalize_output_script(output_script)
         self._opencc_converter = None
 
-        if self.output_script in { "traditional", "traditional_chinese", "zh-tw" }:
+        if self.output_script == "zh-tw":
+            config = "s2t"
+        elif self.output_script == "zh-cn":
+            config = None
+        else:
+            config = None
+
+        if config:
             try:
                 import opencc
-                self._opencc_converter = opencc.OpenCC('s2t')
+                self._opencc_converter = opencc.OpenCC(config)
             except ImportError:
                 warnings.warn(
                     "opencc not installed. Traditional Chinese conversion disabled. "
@@ -401,6 +408,26 @@ class VibeVoiceASRProcessor:
             "speech": audio_array,
             "vae_tok_len": vae_tok_len,
         }
+
+    def _normalize_output_script(self, output_script: Optional[str]) -> Optional[str]:
+        if not output_script:
+            return None
+
+        script = output_script.lower().strip()
+
+        alias_map = {
+            "traditional": "zh-tw",
+            "traditional_chinese": "zh-tw",
+            "zh-tw": "zh-tw",
+            "zh_hant": "zh-tw",
+
+            "simplified": "zh-cn",
+            "simplified_chinese": "zh-cn",
+            "zh-cn": "zh-cn",
+            "zh_hans": "zh-cn",
+        }
+
+        return alias_map.get(script, script)
     
     def _batch_encode(
         self,

--- a/vibevoice/processor/vibevoice_asr_processor.py
+++ b/vibevoice/processor/vibevoice_asr_processor.py
@@ -49,6 +49,7 @@ class VibeVoiceASRProcessor:
         speech_tok_compress_ratio=320,
         target_sample_rate=24000,
         normalize_audio=True,
+        output_script: Optional[str] = None,
         **kwargs
     ):
         self.tokenizer = tokenizer
@@ -64,6 +65,19 @@ class VibeVoiceASRProcessor:
             self.audio_normalizer = AudioNormalizer()
         else:
             self.audio_normalizer = None
+
+        self.output_script = output_script
+        self._opencc_converter = None
+
+        if self.output_script in { "traditional", "traditional_chinese", "zh-tw" }:
+            try:
+                import opencc
+                self._opencc_converter = opencc.OpenCC('s2t')
+            except ImportError:
+                warnings.warn(
+                    "opencc not installed. Traditional Chinese conversion disabled. "
+                    "Install with: pip install opencc-python-reimplemented"
+                )
         
         # Cache special token IDs
         self._cache_special_tokens()
@@ -112,7 +126,8 @@ class VibeVoiceASRProcessor:
         # Try to load configuration
         config_path = os.path.join(pretrained_model_name_or_path, "preprocessor_config.json")
         config = {}
-        
+        output_script = kwargs.pop("output_script", None)
+
         if os.path.exists(config_path):
             with open(config_path, 'r') as f:
                 config = json.load(f)
@@ -160,6 +175,7 @@ class VibeVoiceASRProcessor:
             speech_tok_compress_ratio=speech_tok_compress_ratio,
             target_sample_rate=target_sample_rate,
             normalize_audio=normalize_audio,
+            output_script=output_script,
         )
     
     def save_pretrained(self, save_directory: Union[str, os.PathLike], **kwargs):
@@ -182,6 +198,7 @@ class VibeVoiceASRProcessor:
             "normalize_audio": self.normalize_audio,
             "target_dB_FS": -25,
             "eps": 1e-6,
+            "output_script": self.output_script,
         }
         
         config_path = os.path.join(save_directory, "preprocessor_config.json")
@@ -552,6 +569,12 @@ class VibeVoiceASRProcessor:
                             cleaned_item[mapped_key] = item[key]
                     
                     if cleaned_item:
+                        if self._opencc_converter and "text" in cleaned_item:
+                            try:
+                                cleaned_item["text"] = self._opencc_converter.convert(cleaned_item["text"])
+                            except Exception as e:
+                                logger.warning(f"OpenCC conversion failed: {e}")
+
                         cleaned_result.append(cleaned_item)
             
             return cleaned_result


### PR DESCRIPTION
This PR addresses the request in #271 for Traditional Chinese output support.

## Summary
Adds optional Traditional Chinese output support via post-processing using OpenCC.

## Changes
- Introduced `output_script` parameter to `VibeVoiceASRProcessor`
- Added normalization for `output_script` to support multiple aliases (e.g., `traditional`, `traditional_chinese`, `zh_hant`) mapped to a standard value (`zh-tw`)
- Applies conversion in `post_process_transcription` using OpenCC (optional dependency)
- Persists `output_script` in processor config (save/load)

## Testing
- Verified Simplified → Traditional Chinese conversion
- Verified compatibility with markdown JSON output
- Confirmed no impact when feature is disabled

## Notes
- No changes to model inference or tokenizer behavior
- Fully backward compatible
- OpenCC is optional and gracefully handled if not installed