### PR TITLE
fix: add audio duration validation to prevent OOM in vLLM plugin

### DIFF
--- a/vllm_plugin/inputs.py
+++ b/vllm_plugin/inputs.py
@@ -4,11 +4,20 @@ This module handles audio data loading and preprocessing for VibeVoice ASR infer
 It converts various audio input formats (path, bytes, numpy array) into tensors
 that can be processed by the VibeVoice model.
 """
+import os
+import logging
 import torch
 import numpy as np
 from typing import Union, List
 from vllm.multimodal.inputs import MultiModalInputs
 from vibevoice.processor.audio_utils import load_audio_use_ffmpeg, load_audio_bytes_use_ffmpeg, AudioNormalizer
+
+logger = logging.getLogger(__name__)
+
+# Maximum audio duration in seconds. Default 3660s (61 minutes) matches the
+# model's designed capacity. Override via environment variable to guard against
+# OOM on GPUs with less VRAM. See https://github.com/microsoft/VibeVoice/issues/210
+_MAX_AUDIO_DURATION = float(os.environ.get("VIBEVOICE_MAX_AUDIO_DURATION", "3660"))
 
 
 def load_audio(audio_path: str, target_sr: int = 24000) -> np.ndarray:
@@ -71,7 +80,17 @@ def vibevoice_audio_input_mapper(ctx, data: Union[str, bytes, np.ndarray, List[s
         audio_waveform = data
     else:
         raise ValueError(f"Unsupported audio data type: {type(data)}")
-        
+
+    # Validate audio duration before tensor conversion to catch OOM early
+    duration_sec = len(audio_waveform) / 24000
+    if duration_sec > _MAX_AUDIO_DURATION:
+        raise ValueError(
+            f"Audio duration ({duration_sec:.1f}s) exceeds the configured "
+            f"limit ({_MAX_AUDIO_DURATION:.0f}s). Set the "
+            f"VIBEVOICE_MAX_AUDIO_DURATION environment variable to adjust "
+            f"this limit, or use shorter audio."
+        )
+
     # Convert to tensor
     audio_tensor = torch.from_numpy(audio_waveform).float()
     audio_length = audio_tensor.shape[0]


### PR DESCRIPTION
Prevent opaque CUDA OOM crashes when audio exceeds available VRAM.

Users deploying VibeVoice ASR via vLLM hit CUDA errors with no useful feedback when audio is too long for their GPU. The `vibevoice_audio_input_mapper` in `vllm_plugin/inputs.py` loads and normalizes audio without checking duration, so the model crashes mid-inference.

This adds a duration check after loading, before tensor conversion. Returns a clear `ValueError` with the audio length, configured limit, and the env var name to adjust it.

**Changes:**
- Check `len(audio_waveform) / 24000` against `VIBEVOICE_MAX_AUDIO_DURATION` (env var, default 3660s / 61 min)
- Default matches the model's designed 61-minute capacity (`vllm_plugin/model.py:587`)
- Follows the existing `VIBEVOICE_FFMPEG_MAX_CONCURRENCY` env var pattern in `start_server.py:226`
- 20 lines added, no new files or dependencies

**Error message users see:**
```
ValueError: Audio duration (3720.0s) exceeds the configured limit (3660s).
Set the VIBEVOICE_MAX_AUDIO_DURATION environment variable to adjust this limit,
or use shorter audio.
```

**Demo**

![Demo](https://files.catbox.moe/1pq5am.gif)

**Why this matters:**
- [#210](https://github.com/microsoft/VibeVoice/issues/210) (9 comments): users report CUDA OOM with 1-minute audio on 24GB GPUs
- [#257](https://github.com/microsoft/VibeVoice/issues/257): inconsistent behavior at scale, 33% of requests producing 2-3x expected tokens
- [#243](https://github.com/microsoft/VibeVoice/issues/243): maintainer confirmed H100 80GB handles 30-min audio with 32 concurrent streams

Users with less VRAM can now set `VIBEVOICE_MAX_AUDIO_DURATION=1800` (30 min) to guard against OOM instead of discovering the limit through crashes.

Relates to #210

This contribution was developed with AI assistance (Claude Code).