### PR TITLE
fix: use COMMON_AUDIO_EXTS for --audio_dir file discovery

### DIFF
--- a/demo/vibevoice_asr_inference_from_file.py
+++ b/demo/vibevoice_asr_inference_from_file.py
@@ -20,6 +20,7 @@ from functools import wraps
 
 from vibevoice.modular.modeling_vibevoice_asr import VibeVoiceASRForConditionalGeneration
 from vibevoice.processor.vibevoice_asr_processor import VibeVoiceASRProcessor
+from vibevoice.processor.audio_utils import COMMON_AUDIO_EXTS
 
 
 class VibeVoiceASRBatchInference:
@@ -502,9 +503,10 @@ def main():
         audio_files.extend(args.audio_files)
     
     if args.audio_dir:
-        import glob
-        for ext in ["*.wav", "*.mp3", "*.flac", "*.mp4", "*.m4a", "*.webm"]:
-            audio_files.extend(glob.glob(os.path.join(args.audio_dir, ext)))
+        supported = set(e.lower() for e in COMMON_AUDIO_EXTS)
+        for f in os.listdir(args.audio_dir):
+            if os.path.splitext(f)[1].lower() in supported:
+                audio_files.append(os.path.join(args.audio_dir, f))
     
     if args.dataset:
         concatenated_audio = load_dataset_and_concatenate(


### PR DESCRIPTION
The `--audio_dir` flag in `vibevoice_asr_inference_from_file.py` hardcodes 6 file
extensions (`wav`, `mp3`, `flac`, `mp4`, `m4a`, `webm`) while `audio_utils.py`
supports 25+ formats via FFmpeg. Files like `.ogg`, `.opus`, `.aac`, `.wma` in the
target directory are silently ignored.

This uses `COMMON_AUDIO_EXTS` from `vibevoice.processor.audio_utils` with
case-insensitive matching, consistent with the gradio demo
(`vibevoice_asr_gradio_demo.py:50` already imports this constant).

**Demo**

![Demo](https://files.catbox.moe/vf4apt.gif)

**Changes:** `demo/vibevoice_asr_inference_from_file.py` (+5/-3)
- Import `COMMON_AUDIO_EXTS` from `audio_utils`
- Replace hardcoded glob with `os.listdir` + extension check against `COMMON_AUDIO_EXTS`
- Case-insensitive matching handles `.OGG`, `.Ogg`, etc.

This contribution was developed with AI assistance (Claude Code).