### PR TITLE
fix: reduce max_new_tokens default from 32768 to 4096

### DIFF
--- a/demo/vibevoice_asr_gradio_demo.py
+++ b/demo/vibevoice_asr_gradio_demo.py
@@ -1125,8 +1125,8 @@ def main():
     parser.add_argument(
         "--max_new_tokens",
         type=int,
-        default=32768,
-        help="Default max new tokens for generation (default: 32768)"
+        default=4096,
+        help="Maximum number of tokens to generate (default: 4096)"
     )
     parser.add_argument(
         "--host",

--- a/demo/vibevoice_asr_inference_from_file.py
+++ b/demo/vibevoice_asr_inference_from_file.py
@@ -449,7 +449,7 @@ def main():
     parser.add_argument(
         "--max_new_tokens",
         type=int,
-        default=32768,
+        default=4096,
         help="Maximum number of tokens to generate"
     )
     parser.add_argument(


### PR DESCRIPTION
The default `max_new_tokens=32768` in the ASR demo scripts forces PyTorch to pre-allocate KV-cache for 32K output tokens regardless of actual input length. This causes OOM on 24GB GPUs even for short audio clips (see #210).

4096 tokens is sufficient for transcribing ~1 hour of speech and matches the default already used in `gradio_asr_demo_api_video.py` (line 779). Users who need more can still pass `--max_new_tokens=32768` explicitly.

**Changed files:**
- `demo/vibevoice_asr_inference_from_file.py` — default 32768 → 4096
- `demo/vibevoice_asr_gradio_demo.py` — default 32768 → 4096