### PR TITLE
fix: NameError when no speech output in realtime demo

### DIFF
--- a/demo/realtime_model_inference_from_file.py
+++ b/demo/realtime_model_inference_from_file.py
@@ -266,7 +266,8 @@ def main():
         print(f"RTF (Real Time Factor): {rtf:.2f}x")
     else:
         print("No audio output generated")
-    
+        return
+
     # Calculate token metrics
     input_tokens = inputs['tts_text_ids'].shape[1]  # Number of input tokens
     output_tokens = outputs.sequences.shape[1]  # Total tokens (input + generated)


### PR DESCRIPTION
When \`outputs.speech_outputs\` is empty or None in \`realtime_model_inference_from_file.py\`, the code falls through to lines 284-302 which reference \`audio_duration\`, \`rtf\`, and \`outputs.speech_outputs[0]\` — all undefined in the else branch. This crashes with \`NameError\` or \`IndexError\`.

Added early return when no audio output is generated.