### PR TITLE
fix: prevent int16 overflow in audio scaling

### DIFF
--- a/demo/vibevoice_asr_gradio_demo.py
+++ b/demo/vibevoice_asr_gradio_demo.py
@@ -272,7 +272,7 @@ def clip_and_encode_audio(
             sr = target_sr
         
         # Convert float32 audio to int16 for encoding
-        segment_data_int16 = (segment_data * 32768.0).astype(np.int16)
+        segment_data_int16 = (segment_data * 32767.0).astype(np.int16)
         
         # Convert to MP3 if pydub is available and use_mp3 is True
         if use_mp3 and HAS_PYDUB:
@@ -465,7 +465,7 @@ def slice_audio_to_temp(
     segment = audio_data[start_idx:end_idx]
     temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".wav")
     temp_file.close()
-    segment_int16 = (segment * 32768.0).astype(np.int16)
+    segment_int16 = (segment * 32767.0).astype(np.int16)
     sf.write(temp_file.name, segment_int16, sample_rate, subtype='PCM_16')
     return temp_file.name, None
 
@@ -575,7 +575,7 @@ def transcribe_audio(
             temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".wav")
             audio_path = temp_file.name
             temp_file.close()
-            audio_data_int16 = (audio_array * 32768.0).astype(np.int16)
+            audio_data_int16 = (audio_array * 32767.0).astype(np.int16)
             sf.write(audio_path, audio_data_int16, sample_rate, subtype='PCM_16')
             print(f"[INFO] Microphone audio saved to temp file: {audio_path}")
         

--- a/demo/vibevoice_realtime_demo.py
+++ b/demo/vibevoice_realtime_demo.py
@@ -4,7 +4,7 @@ def main():
     p = argparse.ArgumentParser()
     p.add_argument("--port", type=int, default=3000)
     p.add_argument("--model_path", type=str, default="microsoft/VibeVoice-Realtime-0.5B")
-    p.add_argument("--device", type=str, default="cuda", choices=["cpu", "cuda", "mpx", "mps"])
+    p.add_argument("--device", type=str, default="cuda", choices=["cpu", "cuda", "mps"])
     p.add_argument("--reload", action="store_true", help="Reload the model or not")
     args = p.parse_args()
     

--- a/demo/vibevoice_realtime_demo.py
+++ b/demo/vibevoice_realtime_demo.py
@@ -4,7 +4,7 @@ def main():
     p = argparse.ArgumentParser()
     p.add_argument("--port", type=int, default=3000)
     p.add_argument("--model_path", type=str, default="microsoft/VibeVoice-Realtime-0.5B")
-    p.add_argument("--device", type=str, default="cuda", choices=["cpu", "cuda", "mps"])
+    p.add_argument("--device", type=str, default="cuda", choices=["cpu", "cuda", "mpx", "mps"])
     p.add_argument("--reload", action="store_true", help="Reload the model or not")
     args = p.parse_args()
     


### PR DESCRIPTION
## Summary

Use `32767.0` instead of `32768.0` when converting normalized float32 audio to signed 16-bit PCM in the ASR Gradio demo.

A sample at exactly `+1.0` previously became `32768` before the cast, overflowing int16 to `-32768` and potentially producing a click or pop. The new scale maps the positive endpoint to the representable int16 maximum and matches the convention already used by the API video demo.

The earlier `mpx` removal has been reverted after review confirmed it is an intentional alias handled by `demo/web/app.py`.

## Verification

- Both touched demo modules compile with `py_compile`.
- Diff whitespace check passes.