### PR TITLE
Fix: use torch_dtype instead of dtype in model loading

### DIFF
--- a/demo/vibevoice_asr_gradio_demo.py
+++ b/demo/vibevoice_asr_gradio_demo.py
@@ -72,7 +72,7 @@ class VibeVoiceASRInference:
         print(f"Using attention implementation: {attn_implementation}")
         self.model = VibeVoiceASRForConditionalGeneration.from_pretrained(
             model_path,
-            dtype=dtype,
+            torch_dtype=dtype,
             device_map=device if device == "auto" else None,
             attn_implementation=attn_implementation,
             trust_remote_code=True


### PR DESCRIPTION
This fixes model initialization by replacing the unsupported `dtype` argument 
with `torch_dtype` in from_pretrained().

This ensures compatibility with Hugging Face API and prevents potential issues 
with ignored or invalid parameters.