### PR TITLE
fix: replace bare except with specific Empty exception

### DIFF
--- a/vibevoice/modular/streamer.py
+++ b/vibevoice/modular/streamer.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import torch
 
 import asyncio
-from queue import Queue
+from queue import Empty, Queue
 from typing import TYPE_CHECKING, Optional
 
 
@@ -128,7 +128,7 @@ class AudioBatchIterator:
                     samples_to_remove.add(idx)
                 else:
                     batch_chunks[idx] = value
-            except:
+            except Empty:
                 # Queue is empty for this sample, skip it this iteration
                 pass
         


### PR DESCRIPTION
The `AudioBatchIterator.__next__` method was using a bare `except:` clause which catches all exceptions including system-exiting exceptions like `KeyboardInterrupt` and `SystemExit`.

The code is intended to catch `queue.Empty` exception when the queue has no data. This fix:
1. Imports `Empty` from `queue` module
2. Replaces the bare `except:` with `except Empty:`

This ensures that only the expected empty queue exception is caught, while allowing other exceptions (including bugs) to propagate normally.

Closes #286