### PR TITLE
fix: add vLLM 0.16+ compatibility for multimodal processor APIs

### DIFF
--- a/docs/vllm-version-compatibility.md
+++ b/docs/vllm-version-compatibility.md
@@ -1,0 +1,48 @@
+# vLLM Version Compatibility
+
+VibeVoice's vLLM plugin (`vllm_plugin/model.py`) tracks vLLM's evolving multimodal API surface. This document describes the known breaking changes across vLLM releases and how the plugin handles them.
+
+## Supported vLLM Versions
+
+| vLLM Version | Status | Notes |
+|---|---|---|
+| 0.14.x | ✅ Supported | Original target version. Backward compat shim applied at import time. |
+| 0.16.x | ✅ Supported | Requires `get_data_parser` on `ProcessingInfo` instead of `_get_data_parser` on `Processor`. |
+| 0.18.x | ✅ Supported | `ProcessorInputs` constructor signature changed; base class handles it correctly. |
+
+## API Changes
+
+### vLLM 0.16: `_get_data_parser` → `get_data_parser`
+
+In vLLM 0.16, the multimodal data parser was moved from the processor to the processing info class:
+
+- **Before (0.14):** `BaseMultiModalProcessor._get_data_parser()` — override on the processor class.
+- **After (0.16):** `BaseProcessingInfo.get_data_parser()` — override on the processing info class.
+
+vLLM 0.16 raises `ValueError` if `_get_data_parser` is still defined on the processor:
+
+```
+ValueError: BaseMultiModalProcessor._get_data_parser has been moved to
+BaseProcessingInfo.build_data_parser in v0.16
+```
+
+**Our fix:** The canonical `get_data_parser()` now lives on `VibeVoiceProcessingInfo`. For vLLM < 0.16, a monkey-patch adds `_get_data_parser` back onto `VibeVoiceMultiModalProcessor` at import time via version detection.
+
+### vLLM 0.18: `ProcessorInputs` signature change
+
+In vLLM 0.18, `ProcessorInputs.__init__()` no longer accepts the `mm_data` keyword argument (replaced by `mm_data_items` internally):
+
+```
+TypeError: ProcessorInputs.__init__() got an unexpected keyword argument 'mm_data'
+```
+
+**Our fix:** We removed the custom `get_dummy_processor_inputs` override from `VibeVoiceDummyInputsBuilder`. The base class (`BaseDummyInputsBuilder`) already constructs `ProcessorInputs` correctly for both 0.14 and 0.16+ by using `parse_mm_data()` internally. Our `get_dummy_text()` and `get_dummy_mm_data()` methods are still called by the base implementation.
+
+## Test Verification
+
+Tested on:
+- **vLLM:** 0.16.0
+- **GPU:** NVIDIA L40S (single card)
+- **Workload:** 20-minute audio file
+- **Result:** Completed in 197 seconds
+- **Quality:** Output matches 0.14.x baseline

--- a/vllm_plugin/model.py
+++ b/vllm_plugin/model.py
@@ -476,7 +476,17 @@ class VibeVoiceAudioEncoder(nn.Module):
 
 class VibeVoiceProcessingInfo(BaseProcessingInfo):
     """Processing info for VibeVoice multimodal model."""
-    
+
+    def get_data_parser(self) -> MultiModalDataParser:
+        """Override data parser to set VibeVoice's target sample rate (24kHz).
+
+        In vLLM < 0.16 this lived on the processor as ``_get_data_parser``.
+        vLLM 0.16 moved it here (BaseProcessingInfo.get_data_parser).
+        We override it in *both* places with a version guard so the same
+        codebase works on 0.14.x and 0.16.x.
+        """
+        return MultiModalDataParser(target_sr=24000)
+
     def get_hf_config(self):
         return self.ctx.get_hf_config()
 
@@ -663,17 +673,12 @@ class VibeVoiceDummyInputsBuilder(BaseDummyInputsBuilder[VibeVoiceProcessingInfo
             )
         }
 
-    def get_dummy_processor_inputs(
-        self,
-        seq_len: int,
-        mm_counts: Mapping[str, int],
-        mm_options: Mapping[str, Any] | None = None,
-    ) -> ProcessorInputs:
-        """Build ProcessorInputs for dummy profiling."""
-        return ProcessorInputs(
-            prompt=self.get_dummy_text(mm_counts),
-            mm_data=self.get_dummy_mm_data(seq_len, mm_counts, mm_options),
-        )
+    # get_dummy_processor_inputs is intentionally NOT overridden.
+    # The base class (BaseDummyInputsBuilder) implementation handles the
+    # correct ProcessorInputs construction for both vLLM 0.14 and 0.16.
+    # In 0.14 it uses mm_data=; in 0.16 it uses mm_items= via parse_mm_data.
+    # Our get_dummy_text() and get_dummy_mm_data() are still called by the
+    # base implementation.
 
 
 def _vibevoice_field_config(hf_inputs: Mapping[str, torch.Tensor]):
@@ -707,12 +712,12 @@ class VibeVoiceMultiModalProcessor(BaseMultiModalProcessor[VibeVoiceProcessingIn
     and manages the prompt token replacement for audio placeholders.
     """
     
-    def _get_data_parser(self) -> MultiModalDataParser:
-        """Create a data parser with the correct target sample rate (24kHz)."""
-        # VibeVoice requires 24kHz, not 16kHz (Whisper default)
-        target_sr = 24000
-        return MultiModalDataParser(target_sr=target_sr)
-    
+    # NOTE: In vLLM 0.16, _get_data_parser was moved from
+    # BaseMultiModalProcessor to BaseProcessingInfo.get_data_parser().
+    # vLLM 0.16 raises ValueError if _get_data_parser exists on the processor.
+    # We conditionally define it only for vLLM < 0.16 backward compatibility.
+    # The canonical definition is VibeVoiceProcessingInfo.get_data_parser().
+
     def _call_hf_processor(
         self,
         prompt: str,
@@ -916,6 +921,23 @@ class VibeVoiceMultiModalProcessor(BaseMultiModalProcessor[VibeVoiceProcessingIn
             )
         ]
 
+
+# ============================================================================
+# Backward compat: vLLM < 0.16 reads _get_data_parser from the *processor*,
+# while vLLM >= 0.16 reads get_data_parser from the *processing info* and
+# raises ValueError if _get_data_parser still exists on the processor.
+# We add the old-style method only when running on pre-0.16 vLLM.
+# ============================================================================
+try:
+    import vllm
+    _vllm_version = tuple(int(x) for x in vllm.__version__.split(".")[:2])
+except Exception:
+    _vllm_version = (0, 14)  # conservative fallback
+
+if _vllm_version < (0, 16):
+    def _compat_get_data_parser(self) -> MultiModalDataParser:
+        return MultiModalDataParser(target_sr=24000)
+    VibeVoiceMultiModalProcessor._get_data_parser = _compat_get_data_parser  # type: ignore[attr-defined]
 
 # ============================================================================
 # Main Model Class


### PR DESCRIPTION
## Problem

VibeVoice vLLM plugin fails on vLLM 0.16+ with two errors:

1. **vLLM >= 0.16:**
   ```
   ValueError: BaseMultiModalProcessor._get_data_parser has been moved to BaseProcessingInfo.build_data_parser in v0.16
   ```

2. **vLLM >= 0.18:**
   ```
   TypeError: ProcessorInputs.__init__() got an unexpected keyword argument 'mm_data'
   ```

## Changes

Three modifications to `vllm_plugin/model.py`:

1. **Move `_get_data_parser` → `get_data_parser`**: The canonical data parser (setting target_sr=24kHz) now lives on `VibeVoiceProcessingInfo.get_data_parser()` instead of `VibeVoiceMultiModalProcessor._get_data_parser()`, matching the vLLM 0.16 API.

2. **Remove `get_dummy_processor_inputs` override**: The custom override in `VibeVoiceDummyInputsBuilder` passed `mm_data=` to `ProcessorInputs`, which breaks on vLLM 0.18+ (expects `mm_data_items`). The base class already handles both API versions correctly, so we rely on it while keeping our `get_dummy_text()` and `get_dummy_mm_data()` methods.

3. **Add backward compat shim for vLLM < 0.16**: At import time, we detect the vLLM version. For < 0.16, we monkey-patch `_get_data_parser` onto `VibeVoiceMultiModalProcessor` so the same codebase works on 0.14.x.

Additionally, `docs/vllm-version-compatibility.md` documents supported vLLM versions and API changes.

## Backward Compatibility

- **vLLM 0.14.x**: Fully supported via the version-gated monkey-patch that restores `_get_data_parser` on the processor class.
- **vLLM 0.16.x**: Uses the new `VibeVoiceProcessingInfo.get_data_parser()` natively.
- **vLLM 0.18.x**: Base class handles `ProcessorInputs` construction correctly.

## Testing

- **vLLM version:** 0.16.0
- **GPU:** NVIDIA L40S (single card)
- **Workload:** 20-minute audio file
- **Result:** Completed in 197 seconds, output quality matches 0.14.x baseline

Fixes #259
Related: #231