### PR TITLE
Fix: use except Empty instead of bare except in AudioBatchIterator

### DIFF
--- a/vibevoice/modular/streamer.py
+++ b/vibevoice/modular/streamer.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import torch
 
 import asyncio
-from queue import Queue
+from queue import Queue, Empty
 from typing import TYPE_CHECKING, Optional
 
 
@@ -128,7 +128,7 @@ class AudioBatchIterator:
                     samples_to_remove.add(idx)
                 else:
                     batch_chunks[idx] = value
-            except:
+            except Empty:
                 # Queue is empty for this sample, skip it this iteration
                 pass
         


### PR DESCRIPTION
Closed as duplicate — fixed in #287. Thanks for the contribution!