### PR TITLE
fix: MockCacheLayer.get_mask_sizes must include query_length (breaks SDPA on MPS/CPU)

### DIFF
--- a/vibevoice/modular/modeling_vibevoice_streaming_inference.py
+++ b/vibevoice/modular/modeling_vibevoice_streaming_inference.py
@@ -49,8 +49,9 @@ class MockCacheLayer:
     
     def get_mask_sizes(self, cache_position):
         """Return KV length and offset for mask creation."""
-        kv_length = self.key_cache.shape[2] if self.key_cache is not None else 0
-        return kv_length, 0
+        seq_length = self.key_cache.shape[2] if self.key_cache is not None else 0
+        query_length = cache_position.shape[0]
+        return seq_length + query_length, 0
     
     def update(self, key_states, value_states, cache_kwargs=None):
         """Update the cache with new key/value states."""


### PR DESCRIPTION
## Bug

Closes #312

Streaming TTS inference crashes with a `RuntimeError` on any device that falls back to **SDPA attention** (MPS, CPU, or CUDA without `flash_attn` installed). The model loads successfully but fails on the first multi-token text-window forward pass through the language model.

cc @YaoyaoChang @Damon-Salvetore @pengzhiliang

### Error

```
RuntimeError: The expanded size of the tensor (228) must match the existing size (223)
at non-singleton dimension 3.
Target sizes: [1, 14, 5, 228].  Tensor sizes: [1, 1, 5, 223]
```

### Full traceback

```
File "vibevoice/modular/modeling_vibevoice_streaming_inference.py", line 750, in generate
    outputs = self.forward_lm(
File "vibevoice/modular/modeling_vibevoice_streaming_inference.py", line 375, in forward_lm
    outputs = self.model.language_model(
File "transformers/models/qwen2/modeling_qwen2.py", line 384, in forward
    hidden_states = decoder_layer(
File "transformers/models/qwen2/modeling_qwen2.py", line 169, in forward
    attn_output, attn_weights = attention_interface(
File "transformers/integrations/sdpa_attention.py", line 96, in sdpa_attention_forward
    attn_output = torch.nn.functional.scaled_dot_product_attention(
RuntimeError: The expanded size of the tensor (228) must match the existing size (223) ...
```

### Steps to reproduce

```bash
# Any non-CUDA device, or CUDA without flash_attn installed
python demo/vibevoice_realtime_demo.py \
  --model_path microsoft/VibeVoice-Realtime-0.5B \
  --device mps  # or cpu
# Open browser → type any text → crash on first generation
```

## Root cause

`MockCacheLayer` (introduced for transformers >= 4.57 compatibility) implements `get_mask_sizes()` incorrectly.

In transformers 4.57, the causal mask creation pipeline works as follows:

1. **`Qwen2Model.forward()`** calls `create_causal_mask()` _before_ decoder layers execute
2. **`create_causal_mask()`** → **`_preprocess_mask_arguments()`** calls `past_key_values.get_mask_sizes(cache_position, layer_idx)` to determine `kv_length` — the total KV sequence length the attention mask must cover
3. The returned `kv_length` is used to construct the 4D causal mask of shape `[batch, 1, query_len, kv_length]`
4. Inside each decoder layer, the attention mechanism concatenates new K/V states onto the cache, making the actual KV tensor length = `cache_seq_len + query_len`
5. **SDPA** then requires the mask's last dimension to match the KV tensor length exactly

The **canonical implementation** in `transformers.cache_utils.DynamicLayer` (L123–128) accounts for this:

```python
def get_mask_sizes(self, cache_position: torch.Tensor) -> tuple[int, int]:
    kv_offset = 0
    query_length = cache_position.shape[0]
    kv_length = self.get_seq_length() + query_length  # ← includes upcoming tokens
    return kv_length, kv_offset
```

But `MockCacheLayer.get_mask_sizes()` returned only the cached sequence length:

```python
def get_mask_sizes(self, cache_position):
    kv_length = self.key_cache.shape[2]  # ← missing query_length
    return kv_length, 0
```

This produced a mask that was `query_length` tokens too short (e.g. 223 instead of 228 when `TTS_TEXT_WINDOW_SIZE = 5`), which `torch.nn.functional.scaled_dot_product_attention` rejects as a dimension mismatch.

### Why this didn't surface on CUDA with flash_attention_2

Flash Attention 2 does not use the 4D causal mask from `create_causal_mask()` — it computes causality internally. The `get_mask_sizes()` return value is never used in the flash attention path, so the bug is latent on CUDA+flash_attn setups.

## Fix

Align `MockCacheLayer.get_mask_sizes()` with the `DynamicLayer` contract:

```diff
 def get_mask_sizes(self, cache_position):
     """Return KV length and offset for mask creation."""
-    kv_length = self.key_cache.shape[2] if self.key_cache is not None else 0
-    return kv_length, 0
+    seq_length = self.key_cache.shape[2] if self.key_cache is not None else 0
+    query_length = cache_position.shape[0]
+    return seq_length + query_length, 0
```

## Impact

- **Fixes:** Streaming TTS on MPS (Apple Silicon), CPU, and CUDA without `flash_attn`
- **No effect on:** CUDA with `flash_attention_2` (mask is not used in that code path)
- **Scope:** 1-line change in `MockCacheLayer`, no behavioral change for working configurations

## Environment

| Component | Version |
|-----------|---------|
| macOS | 26.4 (Darwin 25.4.0) |
| Hardware | Apple M4 Max, 64 GB |
| Python | 3.11.15 |
| PyTorch | 2.11.0 (MPS backend) |
| Transformers | 4.57.6 |
| Attention | SDPA (fallback from flash_attention_2) |

## Test plan

- [x] Reproduced the crash on MPS with SDPA — confirmed `get_mask_sizes` returns `(223, 0)` instead of `(228, 0)`
- [x] Applied fix — streaming TTS generation runs without error on MPS
- [x] Verified CPU inference works end-to-end (generated audio shape `[1, 57600]`)
- [x] Verify no regression on CUDA with `flash_attention_2` (no CUDA hardware available — but `get_mask_sizes` is not called in the flash attention path, so no behavioral change is expected)