### PR TITLE
fix: replace bare except with Queue.Empty in streamer.py

### DIFF
--- a/vibevoice/modular/streamer.py
+++ b/vibevoice/modular/streamer.py
@@ -128,7 +128,7 @@ class AudioBatchIterator:
                     samples_to_remove.add(idx)
                 else:
                     batch_chunks[idx] = value
-            except:
+            except Queue.Empty:
                 # Queue is empty for this sample, skip it this iteration
                 pass
         


### PR DESCRIPTION
Closed as duplicate — fixed in #287. Note: `Queue.Empty` doesn't exist in Python, it should be `queue.Empty` or `from queue import Empty`. Thanks for the contribution!