### PR TITLE
docs: minor wording fixes in contributing and VibeVoice guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Our core principles are **code minimalism**, **high readability**, and **functio
 
 - **Over-Engineering**  
   We will reject unnecessary encapsulation, excessive abstraction, or complex architectural refactoring.  
-  Please remember this is research-purposed code, not a commercial enterprise project.
+  Please remember this is research-oriented code, not a commercial enterprise project.
 
 - **Style Tweaks**  
   PRs solely for formatting, beautification, or non-functional style adjustments will be rejected.

--- a/docs/vibevoice-asr.md
+++ b/docs/vibevoice-asr.md
@@ -51,7 +51,7 @@ https://github.com/user-attachments/assets/acde5602-dc17-4314-9e3b-c630bc84aefa
 
 
 ## Installation
-We recommend to use NVIDIA Deep Learning Container to manage the CUDA environment. 
+We recommend using NVIDIA Deep Learning Container to manage the CUDA environment. 
 
 1. Launch docker
 ```bash

--- a/docs/vibevoice-realtime-0.5b.md
+++ b/docs/vibevoice-realtime-0.5b.md
@@ -79,7 +79,7 @@ The model achieves satisfactory performance on short-sentence benchmarks, while 
 
 
 ## Installation
-We recommend to use NVIDIA Deep Learning Container to manage the CUDA environment. 
+We recommend using NVIDIA Deep Learning Container to manage the CUDA environment. 
 
 1. Launch docker
 ```bash
@@ -105,7 +105,7 @@ pip install -e .[streamingtts]
 
 
 ### Usage 1: Launch real-time websocket demo
-Note: NVIDIA T4 / Mac M4 Pro achieve realtime in our tests; other devices with weaker inference capability may require further testing and speed optimizations. 
+Note: NVIDIA T4 / Mac M4 Pro achieve real-time performance in our tests; other devices with weaker inference capability may require further testing and speed optimizations. 
 
 Due to network latency, the time when audio playback is heard may exceed the ~300 ms first speech chunk generation latency.
 ```bash

--- a/docs/vibevoice-tts.md
+++ b/docs/vibevoice-tts.md
@@ -102,9 +102,9 @@ We observed users may encounter occasional instability when synthesizing Chinese
 
 - Using English punctuation even for Chinese text, preferably only commas and periods.
 - Using the Large model variant, which is considerably more stable.
-- If you found the generated voice speak too fast. Please try to chunk your text with multiple speaker turns with same speaker label.
+- If you find that the generated voice speaks too fast, try chunking your text into multiple turns with the same speaker label.
 
-We'd like to thank [PsiPi](https://huggingface.co/PsiPi) for sharing an interesting way for emotion control. Detials can be found via [discussion12](https://huggingface.co/microsoft/VibeVoice-1.5B/discussions/12).
+We'd like to thank [PsiPi](https://huggingface.co/PsiPi) for sharing an interesting way for emotion control. Details can be found via [discussion12](https://huggingface.co/microsoft/VibeVoice-1.5B/discussions/12).
 
 
 ## FAQ


### PR DESCRIPTION
## Summary

Small documentation-only edits for clarity and grammar. No behavior or structure changes.

## Changes

- `CONTRIBUTING.md`: use “research-oriented” instead of “research-purposed.”
- `docs/vibevoice-asr.md` and `docs/vibevoice-realtime-0.5b.md`: “We recommend using …” for the NVIDIA Deep Learning Container install note; in Realtime, clarify the T4 / Mac M4 Pro note as “real-time performance.”
- `docs/vibevoice-tts.md`: tighten the “speaks too fast” tip; fix “Detials” → “Details.”