### PR TITLE
fix: initialize speech_len to prevent NameError in forward()

### DIFF
--- a/vibevoice/modular/modeling_vibevoice.py
+++ b/vibevoice/modular/modeling_vibevoice.py
@@ -415,6 +415,7 @@ class VibeVoiceForConditionalGeneration(VibeVoicePreTrainedModel):
 
         # --- Diffusion Loss Calculation ---
         diffusion_loss = None
+        speech_len = 0  # Initialize to avoid NameError when else branch is taken
         # This block is executed only if we are in a context that involves speech.
         if speech_tensors is not None and acoustic_loss_mask.sum().item() > 0:
             condition_features = hidden_states[acoustic_loss_mask]


### PR DESCRIPTION
## Summary

- Initialize `speech_len = 0` before the if block to prevent `NameError` when the else branch is taken

## Problem

The variable `speech_len` is only defined inside an if block (line 419) when **both** conditions are true:
1. `speech_tensors is not None`
2. `acoustic_loss_mask.sum().item() > 0`

However, it is used in two places outside this block:
- **Line 474**: `output = (logits, speech_len) + ...` — no guard at all
- **Line 480**: `speech_token_num=speech_len if speech_tensors is not None else 0` — guard only checks condition 1, not condition 2

**Edge case**: When `speech_tensors` exists but `acoustic_loss_mask.sum() == 0`, the else branch executes, `speech_len` remains undefined, and accessing it raises `NameError`.

## Fix

Initialize `speech_len = 0` before the if block (1 line change).

## Test plan

- [x] Module imports successfully after fix
- [x] forward() method signature intact
- [x] Static analysis confirms fix addresses the issue

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)