### PR TITLE
fix: correct speech_tok_compress_ratio default value in VibeVoiceASRProcessor

### DIFF
--- a/vibevoice/processor/vibevoice_asr_processor.py
+++ b/vibevoice/processor/vibevoice_asr_processor.py
@@ -37,7 +37,7 @@ class VibeVoiceASRProcessor:
     Args:
         tokenizer: The text tokenizer for processing text
         audio_processor: The audio processor for processing speech
-        speech_tok_compress_ratio (int): Compression ratio for speech tokenization
+        speech_tok_compress_ratio (int): Compression ratio for speech tokenization. Default: 3200 (product of encoder ratios [8,5,5,4,2,2])
         target_sample_rate (int): Target sample rate for audio
         normalize_audio (bool): Whether to normalize audio input
     """
@@ -46,7 +46,7 @@ class VibeVoiceASRProcessor:
         self,
         tokenizer=None,
         audio_processor=None,
-        speech_tok_compress_ratio=320,
+        speech_tok_compress_ratio=3200,
         target_sample_rate=24000,
         normalize_audio=True,
         **kwargs


### PR DESCRIPTION
## Summary

- Fixes a typo/off-by-10x bug in `VibeVoiceASRProcessor.__init__` where `speech_tok_compress_ratio` defaulted to `320` instead of the correct `3200`.
- Updates the docstring to document the correct default value and its derivation.

## Problem

`speech_tok_compress_ratio` is the stride of the acoustic encoder — the product of encoder ratios `[8, 5, 5, 4, 2, 2] = 3200`. It controls how many audio samples map to one speech token:

```python
vae_tok_len = math.ceil(len(audio_array) / self.speech_tok_compress_ratio)
```

With `320` (10× too small), direct instantiation of `VibeVoiceASRProcessor` would compute **10× too many speech placeholder tokens**, producing massively oversized input sequences. For example, a 10-second audio clip at 24 kHz (240,000 samples) would generate `ceil(240000/320) = 750` tokens instead of the correct `ceil(240000/3200) = 75`.

## Root cause

The `from_pretrained()` path already used the correct default of `3200` (matching every other reference in the codebase: `vibevoice_processor.py`, `vibevoice_streaming_processor.py`, `vllm_plugin/model.py`, and the checkpoint conversion script). Only the direct `__init__` parameter had the wrong value.

## Test plan

- [ ] Verify that `VibeVoiceASRProcessor(tokenizer=...).speech_tok_compress_ratio == 3200`
- [ ] Verify that for a 10s audio at 24kHz, `vae_tok_len` is ~75 tokens (not 750)
- [ ] Confirm `from_pretrained` behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)