### PR TITLE
docs: add Python API usage example and output format to vibevoice-asr.md

### DIFF
--- a/docs/vibevoice-asr.md
+++ b/docs/vibevoice-asr.md
@@ -83,7 +83,80 @@ python demo/vibevoice_asr_gradio_demo.py --model_path microsoft/VibeVoice-ASR --
 
 ### Usage 2: Inference from files directly
 ```bash
-python demo/vibevoice_asr_inference_from_file.py --model_path microsoft/VibeVoice-ASR --audio_files [add a audio path here] 
+python demo/vibevoice_asr_inference_from_file.py --model_path microsoft/VibeVoice-ASR --audio_files [add a audio path here]
+```
+
+### Usage 3: Python API — direct inference with hotwords
+
+For programmatic integration, you can use `VibeVoiceASRProcessor` and `VibeVoiceASRForConditionalGeneration` directly:
+
+```python
+import torch
+from vibevoice.modular.modeling_vibevoice_asr import VibeVoiceASRForConditionalGeneration
+from vibevoice.processor.vibevoice_asr_processor import VibeVoiceASRProcessor
+
+model_path = "microsoft/VibeVoice-ASR"
+
+# Load model and processor
+model = VibeVoiceASRForConditionalGeneration.from_pretrained(
+    model_path,
+    torch_dtype=torch.bfloat16,
+    device_map="auto",
+)
+processor = VibeVoiceASRProcessor.from_pretrained(model_path)
+
+# --- Basic transcription ---
+inputs = processor(
+    audio="path/to/audio.wav",
+    return_tensors="pt",
+).to(model.device)
+
+with torch.no_grad():
+    output_ids = model.generate(**inputs, max_new_tokens=32768)
+
+transcription = processor.batch_decode(output_ids, skip_special_tokens=True)[0]
+print(transcription)
+
+# --- With customized hotwords ---
+# Hotwords improve recognition of proper nouns, technical terms, or speaker names.
+# Pass them as a comma-separated string via context_info.
+inputs = processor(
+    audio="path/to/audio.wav",
+    context_info="Microsoft, Azure, VibeVoice",  # domain-specific terms
+    return_tensors="pt",
+).to(model.device)
+
+with torch.no_grad():
+    output_ids = model.generate(**inputs, max_new_tokens=32768)
+
+transcription = processor.batch_decode(output_ids, skip_special_tokens=True)[0]
+```
+
+### Output format
+
+The model produces a JSON array where each element represents one speech segment, containing:
+
+- **`Start time`** — segment start time in seconds
+- **`End time`** — segment end time in seconds
+- **`Speaker ID`** — speaker identifier (e.g., `"SPEAKER_00"`, `"SPEAKER_01"`)
+- **`Content`** — transcribed text for this segment
+
+Example output for a two-speaker recording:
+
+```json
+[
+  {"Start time": 0.0, "End time": 12.5, "Speaker ID": "SPEAKER_00", "Content": "Welcome to our podcast. Today we're discussing AI research."},
+  {"Start time": 12.8, "End time": 25.3, "Speaker ID": "SPEAKER_01", "Content": "Thanks for having me. I've been working on speech models for five years."},
+  {"Start time": 25.5, "End time": 38.0, "Speaker ID": "SPEAKER_00", "Content": "Let's start with the basics. How does automatic speech recognition work?"}
+]
+```
+
+The `post_process_transcription` helper on the processor can parse this JSON into a list of Python dicts:
+
+```python
+segments = processor.post_process_transcription(transcription)
+for seg in segments:
+    print(f"[{seg['start_time']:.1f}s – {seg['end_time']:.1f}s] {seg['speaker_id']}: {seg['text']}")
 ```
 
 


### PR DESCRIPTION
## Summary

- Adds **Usage 3: Python API** section to `docs/vibevoice-asr.md` showing direct programmatic use of `VibeVoiceASRProcessor` and `VibeVoiceASRForConditionalGeneration`
- Documents the **structured JSON output format** produced by the model (per-segment timestamps, speaker IDs, transcribed text)
- Shows how to use **customized hotwords** via the `context_info` parameter
- Shows how to use `post_process_transcription()` to parse the model output into Python dicts

## Motivation

The existing documentation only covers the Gradio demo and a CLI script. Many users want to integrate VibeVoice ASR directly into Python applications. Issue #318 is one example where users are unclear about how the model works and what its output format is. There are no code examples showing:
1. How to load and call the processor and model directly
2. How to pass hotwords/context
3. What the output JSON looks like, or how to parse it

This PR fills those gaps with minimal, self-contained examples.

## Changes

- `docs/vibevoice-asr.md`: added Usage 3 section with two code examples (basic and with hotwords) plus an output format section with a JSON example and `post_process_transcription` usage

## Test plan

- [ ] Verify the code snippets match the actual class APIs in `vibevoice/processor/vibevoice_asr_processor.py` and `vibevoice/modular/modeling_vibevoice_asr.py`
- [ ] Confirm the JSON output format matches real model output

🤖 Generated with [Claude Code](https://claude.com/claude-code)