### PR TITLE
fix: prevent IndexError when voice presets directory is empty

### DIFF
--- a/demo/realtime_model_inference_from_file.py
+++ b/demo/realtime_model_inference_from_file.py
@@ -78,6 +78,11 @@ class VoiceMapper:
             return matched_path
         
         # Default to first voice if no match found
+        if not self.voice_presets:
+            raise ValueError(
+                f"No voice presets available. Please download voices first using: "
+                f"bash demo/download_experimental_voices.sh"
+            )
         default_voice = list(self.voice_presets.values())[0]
         print(f"Warning: No voice preset found for '{speaker_name}', using default voice: {default_voice}")
         return default_voice


### PR DESCRIPTION
## Summary

Add validation before accessing `voice_presets` dict to prevent `IndexError` when the voices directory doesn't exist or contains no `.pt` files.

## Problem

In `VoiceMapper.get_voice_path()`, line 81 attempts to access the first element of an empty dictionary:

```python
default_voice = list(self.voice_presets.values())[0]  # IndexError if empty!
```

This crashes with `IndexError: list index out of range` when:
1. The `demo/voices/streaming_model/` directory doesn't exist
2. The directory exists but contains no `.pt` files

## Fix

Add a check before accessing the dictionary, with a helpful error message pointing users to the download script:

```python
if not self.voice_presets:
    raise ValueError(
        f"No voice presets available. Please download voices first using: "
        f"bash demo/download_experimental_voices.sh"
    )
```

## Test plan

- [x] Verified fix prevents IndexError
- [x] Error message points to download script
- [x] Normal operation unaffected when voices exist

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)