### PR TITLE
fix: initialize speech_len to prevent NameError in forward()

### DIFF
--- a/vibevoice/modular/modeling_vibevoice.py
+++ b/vibevoice/modular/modeling_vibevoice.py
@@ -415,6 +415,7 @@ class VibeVoiceForConditionalGeneration(VibeVoicePreTrainedModel):
 
         # --- Diffusion Loss Calculation ---
         diffusion_loss = None
+        speech_len = 0  # Initialize to prevent NameError when else branch is taken
         # This block is executed only if we are in a context that involves speech.
         if speech_tensors is not None and acoustic_loss_mask.sum().item() > 0:
             condition_features = hidden_states[acoustic_loss_mask]


### PR DESCRIPTION
## Summary

Initialize `speech_len = 0` before the if block to prevent `NameError` when the else branch is taken (fixes #319).

## Problem

The variable `speech_len` is only defined inside an if block when both conditions are true:
1. `speech_tensors is not None`
2. `acoustic_loss_mask.sum().item() > 0`

However, it is used in two places outside this block:
- **Line 474**: `output = (logits, speech_len) + ...`
- **Line 480**: `speech_token_num=speech_len if speech_tensors is not None else 0`

When `speech_tensors` exists but `acoustic_loss_mask.sum() == 0`, the else branch executes, `speech_len` remains undefined, and accessing it raises `NameError`.

## Fix

Initialize `speech_len = 0` before the if block (1 line change).

## Test plan

- [x] Module imports successfully after fix
- [x] forward() method signature intact
- [x] Static analysis confirms fix addresses the issue

---

Good day maintainers! Thank you for your work on this project. I hope this fix can be helpful. If there are any issues with my solution, please let me know and I will address them.

Warmly,
SparkLabScout