### PR TITLE
Fix streaming generation compatibility

### DIFF
--- a/vibevoice/modular/configuration_vibevoice_streaming.py
+++ b/vibevoice/modular/configuration_vibevoice_streaming.py
@@ -78,6 +78,8 @@ class VibeVoiceStreamingConfig(PretrainedConfig):
         self.acoustic_vae_dim = getattr(self.acoustic_tokenizer_config, 'vae_dim', 64)
         # The decoder of the model is divided into two components. The lower Transformer layers are only used for encoding text, while the upper Transformer layers are used for encoding text and generating speech. `tts_backbone_num_hidden_layers` indicates the number of upper layers used for TTS.
         self.tts_backbone_num_hidden_layers = tts_backbone_num_hidden_layers
+        # Newer transformers generation helpers expect a top-level num_hidden_layers field.
+        self.num_hidden_layers = getattr(self.decoder_config, "num_hidden_layers", self.tts_backbone_num_hidden_layers)
 
         super().__init__(**kwargs)
 


### PR DESCRIPTION
## Summary
- add a top-level `num_hidden_layers` field to `VibeVoiceStreamingConfig` for newer transformers generation helpers
- keep the fix isolated to the streaming configuration surface

## Why
Recent transformers generation helpers expect `num_hidden_layers` to be available from the top-level config. Without it, the streaming generation path can break on newer dependency versions.

## Notes
- the fork branch was rebased onto the latest `wonderstone/main`
- the cache initialization compatibility logic already exists upstream on the fork base, so this PR only carries the remaining config-level fix