### PR TITLE
fix(demo): free GPU tensors between batches to prevent VRAM accumulation

### DIFF
--- a/demo/vibevoice_asr_inference_from_file.py
+++ b/demo/vibevoice_asr_inference_from_file.py
@@ -6,6 +6,7 @@ This script supports batch inference for ASR model and compares results
 between batch processing and single-sample processing.
 """
 
+import gc
 import os
 import sys
 import torch
@@ -202,9 +203,31 @@ class VibeVoiceASRBatchInference:
         
         print(f"  Total generation time: {generation_time:.2f}s")
         print(f"  Average time per sample: {generation_time/batch_size:.2f}s")
-        
+
+        # Release the large input/output tensors back to the CUDA allocator so that
+        # VRAM does not accumulate across consecutive batches when processing many files
+        # (see https://github.com/microsoft/VibeVoice/issues/368).
+        del inputs, output_ids
+        self._release_device_cache()
+
         return results
-    
+
+    def _release_device_cache(self) -> None:
+        """Return any cached device memory to the allocator and run a GC cycle."""
+        if self.device == "cuda" and torch.cuda.is_available():
+            torch.cuda.empty_cache()
+        gc.collect()
+
+    def close(self) -> None:
+        """Release the model and processor from device memory.
+
+        Call this when the instance is no longer needed — especially after processing
+        many files on GPU — to return all VRAM to the allocator before loading another
+        model in the same process.
+        """
+        del self.model, self.processor
+        self._release_device_cache()
+
     def transcribe_with_batching(
         self,
         audio_inputs: List,
@@ -246,7 +269,8 @@ class VibeVoiceASRBatchInference:
                 num_beams=num_beams,
             )
             all_results.extend(batch_results)
-        
+            self._release_device_cache()
+
         return all_results
 
 
@@ -558,16 +582,19 @@ def main():
     print(f"Processing {len(all_audio_inputs)} audio(s)")
     print("="*80)
     
-    all_results = asr.transcribe_with_batching(
-        all_audio_inputs,
-        batch_size=args.batch_size,
-        max_new_tokens=args.max_new_tokens,
-        temperature=args.temperature,
-        top_p=args.top_p,
-        do_sample=do_sample,
-        num_beams=args.num_beams,
-    )
-    
+    try:
+        all_results = asr.transcribe_with_batching(
+            all_audio_inputs,
+            batch_size=args.batch_size,
+            max_new_tokens=args.max_new_tokens,
+            temperature=args.temperature,
+            top_p=args.top_p,
+            do_sample=do_sample,
+            num_beams=args.num_beams,
+        )
+    finally:
+        asr.close()
+
     # Print results
     print("\n" + "="*80)
     print("Results")


### PR DESCRIPTION
## Problem

When `--audio_files` contains multiple files, `transcribe_with_batching()` loops over
batches and calls `transcribe_batch()` for each. Inside `transcribe_batch()`, two large
GPU tensors are created:

- `inputs` — the padded batch of speech features moved to device
- `output_ids` — the generated token ids from `model.generate()`

Neither is explicitly freed before the function returns. Python's reference-count GC
does not guarantee immediate CUDA memory deallocation, so the allocator cannot reclaim
VRAM between iterations. After 2–3 batches of 25-min audio on a 24 GB GPU the process
OOMs even though each individual batch fits comfortably (issue #368).

## Fix

Three targeted changes, no logic modifications:

1. **`transcribe_batch()`** — `del inputs, output_ids` immediately after the decode loop,
   then flush the CUDA allocator via `torch.cuda.empty_cache()`.

2. **`_release_device_cache()` helper** — 2-line private method (`empty_cache` + `gc.collect`)
   called from the three callsites that need it; avoids repeating the pair inline.

3. **`close()` method** — explicit teardown for callers who want to reclaim all VRAM after
   processing (e.g. before loading a second model in the same process). The `main()` entry
   point wraps inference in `try/finally` to call it on both normal exit and exception.

## Verification

- No change to any transcription output or model weights.
- Argument signatures of `transcribe_batch` and `transcribe_with_batching` are unchanged.
- All existing demo usage (`python demo/vibevoice_asr_inference_from_file.py ...`) works as before.

Fixes #368