### PR TITLE
Fix int16 audio overflow in ASR Gradio demo

### DIFF
--- a/demo/vibevoice_asr_gradio_demo.py
+++ b/demo/vibevoice_asr_gradio_demo.py
@@ -295,7 +295,8 @@ def clip_and_encode_audio(
             sr = target_sr
         
         # Convert float32 audio to int16 for encoding
-        segment_data_int16 = (segment_data * 32768.0).astype(np.int16)
+        # Use 32767.0 instead of 32768.0 to avoid potential overflow
+        segment_data_int16 = np.clip(segment_data * 32767.0, -32767, 32767).astype(np.int16)
         
         # Convert to MP3 if pydub is available and use_mp3 is True
         if use_mp3 and HAS_PYDUB:
@@ -488,7 +489,8 @@ def slice_audio_to_temp(
     segment = audio_data[start_idx:end_idx]
     temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".wav")
     temp_file.close()
-    segment_int16 = (segment * 32768.0).astype(np.int16)
+    # Use 32767.0 instead of 32768.0 to avoid potential overflow
+    segment_int16 = np.clip(segment * 32767.0, -32767, 32767).astype(np.int16)
     sf.write(temp_file.name, segment_int16, sample_rate, subtype='PCM_16')
     return temp_file.name, None
 


### PR DESCRIPTION
## Summary
- Fix float32→int16 audio conversion that uses `32768.0` instead of `32767.0`, causing integer overflow when audio amplitude >= 1.0
- The overflow wraps values to negative numbers, producing audible distortion
- Added `np.clip` to guard against out-of-range values
- This aligns with the existing fix in `gradio_asr_demo_api_video.py` (line 586) which already uses `32767.0` with the comment "Use 32767.0 instead of 32768.0 to avoid potential overflow"

## Details

**Affected file:** `demo/vibevoice_asr_gradio_demo.py` (lines 298 and 491)

The int16 range is [-32768, 32767]. Multiplying a float value of `1.0` by `32768.0` gives `32768.0`, which overflows to `-32768` when cast to `np.int16`.

## Test plan
- [ ] Verify audio playback quality in the Gradio demo has no distortion for loud audio segments
- [ ] Verify the fix matches the approach already used in `gradio_asr_demo_api_video.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)