### PR TITLE
Fix unsafe torch.load with weights_only=False

### DIFF
--- a/demo/realtime_model_inference_from_file.py
+++ b/demo/realtime_model_inference_from_file.py
@@ -222,7 +222,7 @@ def main():
     target_device = args.device if args.device != "cpu" else "cpu"
     voice_sample = voice_mapper.get_voice_path(args.speaker_name)
     print(f"Using voice preset for {args.speaker_name}: {voice_sample}")
-    all_prefilled_outputs = torch.load(voice_sample, map_location=target_device, weights_only=False)
+    all_prefilled_outputs = torch.load(voice_sample, map_location=target_device, weights_only=True)
 
     # Prepare inputs for the model
     inputs = processor.process_input_with_cached_prompt(

--- a/demo/web/app.py
+++ b/demo/web/app.py
@@ -161,7 +161,7 @@ class StreamingTTSService:
             prefilled_outputs = torch.load(
                 preset_path,
                 map_location=self._torch_device,
-                weights_only=False,
+                weights_only=True,
             )
             self._voice_cache[key] = prefilled_outputs
 


### PR DESCRIPTION
## Summary
- Fix `torch.load` calls in `demo/realtime_model_inference_from_file.py` and `demo/web/app.py` to use `weights_only=True`
- Using `weights_only=False` allows arbitrary code execution via pickled objects in `.pt` files
- The loaded files contain dicts of tensors (cached prompt outputs) which are fully supported by `weights_only=True` in PyTorch 2.0+
- This aligns with the existing safe usage in `vibevoice_tokenizer_processor.py` which already uses `weights_only=True`

## Details

**Affected files:**
- `demo/realtime_model_inference_from_file.py` (line 225)
- `demo/web/app.py` (line 161-164)

**Security impact:** If a malicious `.pt` file were provided (e.g., a poisoned voice preset), `weights_only=False` would allow it to execute arbitrary code on the host machine via Python's pickle deserialization.

## Test plan
- [ ] Verify voice presets load correctly with `weights_only=True`
- [ ] Verify the loaded data structure is a dict of tensors (no custom Python objects)

🤖 Generated with [Claude Code](https://claude.com/claude-code)