### PR TITLE
Fix audio resampling: use librosa.resample instead of np.interp

### DIFF
--- a/demo/vibevoice_asr_inference_from_file.py
+++ b/demo/vibevoice_asr_inference_from_file.py
@@ -323,13 +323,8 @@ def load_dataset_and_concatenate(
             
             # Resample if needed
             if sr != target_sr:
-                duration = len(audio_array) / sr
-                new_length = int(duration * target_sr)
-                audio_array = np.interp(
-                    np.linspace(0, len(audio_array) - 1, new_length),
-                    np.arange(len(audio_array)),
-                    audio_array
-                )
+                import librosa
+                audio_array = librosa.resample(audio_array, orig_sr=sr, target_sr=target_sr)
             
             chunk_duration = len(audio_array) / target_sr
             


### PR DESCRIPTION
## Summary
- Replace `np.interp` (linear waveform interpolation) with `librosa.resample` for audio resampling in `demo/vibevoice_asr_inference_from_file.py`
- `np.interp` is not a valid resampling method — it introduces aliasing artifacts by not applying an anti-aliasing filter before decimation/interpolation
- `librosa.resample` uses proper band-limited sinc interpolation

## Details

**Affected file:** `demo/vibevoice_asr_inference_from_file.py` (lines 325-332)

The original code used `np.interp` to downsample audio waveforms by linearly interpolating sample values. This approach does not include an anti-aliasing filter, so high-frequency components fold back into the audible range as artifacts. `librosa.resample` is already used elsewhere in this project (`vibevoice_tokenizer_processor.py`, `vibevoice_asr_processor.py`).

## Test plan
- [ ] Run the ASR inference demo with audio files that require resampling
- [ ] Verify the transcription quality is preserved or improved

🤖 Generated with [Claude Code](https://claude.com/claude-code)