### PR TITLE
Fix CFG denoising: use unconditional sample for unconditional branch

### DIFF
--- a/vibevoice/modular/modeling_vibevoice_streaming_inference.py
+++ b/vibevoice/modular/modeling_vibevoice_streaming_inference.py
@@ -890,7 +890,8 @@ class VibeVoiceStreamingForConditionalGenerationInference(VibeVoiceStreamingPreT
         speech = torch.randn(condition.shape[0], self.config.acoustic_vae_dim).to(condition)
         for t in self.model.noise_scheduler.timesteps:
             half = speech[: len(speech) // 2]
-            combined = torch.cat([half, half], dim=0)
+            other_half = speech[len(speech) // 2:]
+            combined = torch.cat([half, other_half], dim=0)
             eps = self.model.prediction_head(combined, t.repeat(combined.shape[0]).to(combined), condition=condition)
             cond_eps, uncond_eps = torch.split(eps, len(eps) // 2, dim=0)
             half_eps = uncond_eps + cfg_scale * (cond_eps - uncond_eps)


### PR DESCRIPTION
## Summary
- Fix Classifier-Free Guidance (CFG) denoising in `sample_speech_tokens` to use the actual unconditional sample instead of duplicating the conditional sample
- The unconditional half of the speech tensor was being replaced with a copy of the conditional half before prediction, making CFG mathematically incorrect

## Details

**Affected file:** `vibevoice/modular/modeling_vibevoice_streaming_inference.py` (lines 887-899)

The original code:
```python
half = speech[: len(speech) // 2]
combined = torch.cat([half, half], dim=0)  # ← duplicates conditional half
```

The fix:
```python
half = speech[: len(speech) // 2]
other_half = speech[len(speech) // 2:]
combined = torch.cat([half, other_half], dim=0)  # ← uses both halves
```

In standard CFG, the model receives both the conditional sample (with the conditioning) and the unconditional sample (without). By duplicating the conditional half for both inputs, the unconditional noise prediction was computed from the wrong sample, producing incorrect CFG scaling. Only the conditional half is returned as output, but the unconditional branch still needs proper evolution through the denoising steps for CFG to work correctly.

## Test plan
- [ ] Run streaming TTS inference with cfg_scale > 1.0 and verify output quality
- [ ] Compare output quality before and after the fix with the same seed

🤖 Generated with [Claude Code](https://claude.com/claude-code)