### PR TITLE
Fix bare except blocks that silently swallow all errors

### DIFF
--- a/vllm_plugin/__init__.py
+++ b/vllm_plugin/__init__.py
@@ -43,14 +43,14 @@ def register_vibevoice():
             slow_tokenizer_class=Qwen2Tokenizer,
             fast_tokenizer_class=VibeVoiceASRTextTokenizerFast,
         )
-    except Exception:
-        pass  # May already be registered
+    except ValueError:
+        pass  # Already registered
 
     # Register the processor with transformers
     try:
         AutoProcessor.register(VibeVoiceConfig, processor_class=Qwen2AudioProcessor)
-    except Exception:
-        pass  # May already be registered
+    except ValueError:
+        pass  # Already registered
 
     # Register the model class with the architecture name "VibeVoice"
     # This name must match the "architectures" list in config.json


### PR DESCRIPTION
## Summary
- Replace `except Exception: pass` with `except ValueError: pass` in the vLLM plugin registration code
- The broad `Exception` handler hides real bugs (TypeError, AttributeError, etc.) that indicate a genuine problem, not just "already registered"
- The transformers registry raises `ValueError` when a config class is already registered, so catching `ValueError` is sufficient

## Details

**Affected file:** `vllm_plugin/__init__.py` (lines 40-53)

If the registration fails for a reason other than "already registered" (e.g., wrong argument types, missing attributes), the error would be silently swallowed and the model would malfunction later with no indication of the root cause.

## Test plan
- [ ] Verify the vLLM plugin still loads correctly on first invocation
- [ ] Verify the plugin still works when loaded multiple times (already-registered case)
- [ ] Verify that genuine registration errors are now properly raised

🤖 Generated with [Claude Code](https://claude.com/claude-code)