### PR TITLE
Replace deprecated @app.on_event with lifespan context manager

### DIFF
--- a/demo/web/app.py
+++ b/demo/web/app.py
@@ -332,17 +332,16 @@ class StreamingTTSService:
         return pcm.tobytes()
 
 
-app = FastAPI()
+from contextlib import asynccontextmanager
 
-
-@app.on_event("startup")
-async def _startup() -> None:
+@asynccontextmanager
+async def lifespan(app: FastAPI):
     model_path = os.environ.get("MODEL_PATH")
     if not model_path:
         raise RuntimeError("MODEL_PATH not set in environment")
 
     device = os.environ.get("MODEL_DEVICE", "cuda")
-    
+
     service = StreamingTTSService(
         model_path=model_path,
         device=device
@@ -354,6 +353,10 @@ async def _startup() -> None:
     app.state.device = device
     app.state.websocket_lock = asyncio.Lock()
     print("[startup] Model ready.")
+    yield
+
+
+app = FastAPI(lifespan=lifespan)
 
 
 def streaming_tts(text: str, **kwargs) -> Iterator[np.ndarray]:


### PR DESCRIPTION
## Summary
- Replace deprecated `@app.on_event("startup")` with the recommended `lifespan` context manager pattern in `demo/web/app.py`
- `@app.on_event("startup")` is deprecated since FastAPI 0.103.0 and will be removed in a future version

## Details

**Affected file:** `demo/web/app.py` (lines 335-356)

The deprecated `on_event("startup")` pattern has known issues with auto-reload where the startup event may fire multiple times, loading multiple copies of the large model into GPU memory and causing OOM. The lifespan context manager is the recommended replacement.

## Test plan
- [ ] Start the web app with `MODEL_PATH` set and verify it loads correctly
- [ ] Verify WebSocket streaming still works after the change
- [ ] Verify startup errors (e.g., missing MODEL_PATH) are still properly raised

🤖 Generated with [Claude Code](https://claude.com/claude-code)