### PR TITLE
fix: load voice presets with a restricted unpickler (CWE-502)

### DIFF
--- a/demo/realtime_model_inference_from_file.py
+++ b/demo/realtime_model_inference_from_file.py
@@ -9,9 +9,7 @@ import copy
 import glob
 
 from vibevoice.modular.modeling_vibevoice_streaming_inference import VibeVoiceStreamingForConditionalGenerationInference
-from vibevoice.processor.vibevoice_streaming_processor import VibeVoiceStreamingProcessor
-from transformers.cache_utils import DynamicCache
-from transformers.modeling_outputs import BaseModelOutputWithPast
+from vibevoice.processor.vibevoice_streaming_processor import VibeVoiceStreamingProcessor, load_voice_preset
 from transformers.utils import logging
 
 logging.set_verbosity_info()
@@ -224,8 +222,7 @@ def main():
     target_device = args.device if args.device != "cpu" else "cpu"
     voice_sample = voice_mapper.get_voice_path(args.speaker_name)
     print(f"Using voice preset for {args.speaker_name}: {voice_sample}")
-    with torch.serialization.safe_globals([BaseModelOutputWithPast, DynamicCache]):
-        all_prefilled_outputs = torch.load(voice_sample, map_location=target_device, weights_only=True)
+    all_prefilled_outputs = load_voice_preset(voice_sample, map_location=target_device)
 
     # Prepare inputs for the model
     inputs = processor.process_input_with_cached_prompt(

--- a/demo/web/app.py
+++ b/demo/web/app.py
@@ -11,8 +11,6 @@ from typing import Any, Callable, Dict, Iterator, Optional, Tuple, cast
 
 import numpy as np
 import torch
-from transformers.cache_utils import DynamicCache
-from transformers.modeling_outputs import BaseModelOutputWithPast
 from fastapi import FastAPI, WebSocket
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
@@ -23,6 +21,7 @@ from vibevoice.modular.modeling_vibevoice_streaming_inference import (
 )
 from vibevoice.processor.vibevoice_streaming_processor import (
     VibeVoiceStreamingProcessor,
+    load_voice_preset,
 )
 from vibevoice.modular.streamer import AudioStreamer
 
@@ -160,12 +159,9 @@ class StreamingTTSService:
             preset_path = self.voice_presets[key]
             print(f"[startup] Loading voice preset {key} from {preset_path}")
             print(f"[startup] Loading prefilled prompt from {preset_path}")
-            with torch.serialization.safe_globals([BaseModelOutputWithPast, DynamicCache]):
-                prefilled_outputs = torch.load(
-                    preset_path,
-                    map_location=self._torch_device,
-                    weights_only=True,
-                )
+            prefilled_outputs = load_voice_preset(
+                preset_path, map_location=self._torch_device
+            )
             self._voice_cache[key] = prefilled_outputs
 
         return self._voice_cache[key]

--- a/vibevoice/processor/vibevoice_streaming_processor.py
+++ b/vibevoice/processor/vibevoice_streaming_processor.py
@@ -1,4 +1,6 @@
+import io
 import math
+import pickle
 import warnings
 from typing import List, Optional, Union, Dict, Any, Tuple
 import os
@@ -12,6 +14,71 @@ from transformers.utils import TensorType, logging
 from .vibevoice_tokenizer_processor import AudioNormalizer
 
 logger = logging.get_logger(__name__)
+
+
+# Globals that legitimately appear in the cached voice-prompt (.pt) files. Any
+# other global (e.g. os.system) is refused, so a tampered preset cannot execute
+# arbitrary code when it is loaded (CWE-502).
+_VOICE_PRESET_SAFE_GLOBALS = {
+    ("collections", "OrderedDict"),
+    ("transformers.modeling_outputs", "BaseModelOutputWithPast"),
+    ("transformers.cache_utils", "DynamicCache"),
+}
+
+
+class _VoicePresetUnpickler(pickle.Unpickler):
+    """Unpickler that only resolves the classes used by voice presets."""
+
+    def find_class(self, module, name):
+        if (module, name) in _VOICE_PRESET_SAFE_GLOBALS:
+            return super().find_class(module, name)
+        # torch tensor-rebuilding primitives; the storages they reference are
+        # restored by torch.load's persistent_load, not through find_class.
+        if module == "torch._utils" and name.startswith("_rebuild_"):
+            return super().find_class(module, name)
+        if module == "torch" and name.endswith("Storage"):
+            return super().find_class(module, name)
+        raise pickle.UnpicklingError(
+            f"Refusing to load disallowed global '{module}.{name}' from voice preset"
+        )
+
+
+class _RestrictedPickleModule:
+    """``pickle_module`` exposing the restricted unpickler to ``torch.load``.
+
+    ``torch.load`` uses ``Unpickler`` for the main payload and the module-level
+    ``load``/``loads`` for legacy-format metadata, so all three must enforce the
+    same restriction.
+    """
+
+    Unpickler = _VoicePresetUnpickler
+
+    @staticmethod
+    def load(file, **kwargs):
+        return _VoicePresetUnpickler(file, **kwargs).load()
+
+    @staticmethod
+    def loads(data, **kwargs):
+        return _VoicePresetUnpickler(io.BytesIO(data), **kwargs).load()
+
+
+def load_voice_preset(path, map_location=None):
+    """Load a cached voice-prompt file produced for streaming TTS.
+
+    The presets store ``transformers`` ``BaseModelOutputWithPast`` /
+    ``DynamicCache`` objects (``dict`` subclasses), which
+    ``torch.load(weights_only=True)`` cannot rebuild because its unpickler
+    forbids ``SETITEMS`` on ``dict`` subclasses. A restricted unpickler is used
+    instead: it permits only those container classes and torch's tensor
+    primitives, keeping the protection against arbitrary code execution that
+    ``weights_only=True`` was added for (CWE-502).
+    """
+    return torch.load(
+        path,
+        map_location=map_location,
+        pickle_module=_RestrictedPickleModule,
+        weights_only=False,
+    )
 
 
 class VibeVoiceStreamingProcessor:


### PR DESCRIPTION
## Summary

- The voice-preset loaders in `demo/web/app.py` and `demo/realtime_model_inference_from_file.py` crash on startup, making the streaming web demo and the realtime file demo unusable on PyTorch >= 2.6 (#392).
- Load the presets through a restricted `pickle.Unpickler` that keeps the CWE-502 protection while actually being able to reconstruct the objects.

## Problem

Commit 303b283 changed both loaders to `torch.load(..., weights_only=True)` wrapped in `torch.serialization.safe_globals([BaseModelOutputWithPast, DynamicCache])` to close a CWE-502 risk (arbitrary code execution from a tampered `.pt`).

The presets are `dict`s of `transformers.modeling_outputs.BaseModelOutputWithPast` objects (each holding a `last_hidden_state` tensor and a `DynamicCache`). PyTorch's weights-only unpickler refuses the `SETITEMS` opcode on `dict` subclasses — it accepts only the exact `dict`, `OrderedDict` and `Counter` types, even when the subclass is allowlisted via `safe_globals`. So the load can never succeed and aborts on startup with:

```
_pickle.UnpicklingError: Weights only load failed. ...
Can only SETITEMS for dict, collections.OrderedDict, collections.Counter,
but got <class 'transformers.modeling_outputs.BaseModelOutputWithPast'>
```

`BaseModelOutputWithPast` has to stay an object — the model accesses `outputs.past_key_values` and `outputs.last_hidden_state` — so the presets cannot simply be flattened to plain tensors.

## Fix

Add a shared `load_voice_preset` helper in `vibevoice/processor/vibevoice_streaming_processor.py` (imported by both demos) that loads via a restricted `pickle.Unpickler`:

- `find_class` resolves only the container classes the presets are built from (`OrderedDict`, `BaseModelOutputWithPast`, `DynamicCache`) and torch's tensor-rebuilding primitives (`torch._utils._rebuild_*`, `torch.*Storage`). Any other global, e.g. `os.system`, raises `UnpicklingError`, so a tampered preset still cannot execute arbitrary code — the CWE-502 protection is preserved.
- The same restriction is applied to the module-level `load` / `loads` that `torch.load` uses for legacy-format metadata, so both the zip and legacy serialization formats stay safe.

Because the restricted unpickler uses standard pickle semantics, `SETITEMS` on `BaseModelOutputWithPast` works and the objects load correctly. The now-unused `BaseModelOutputWithPast` / `DynamicCache` imports are removed from both demos.

## Test plan

Validated on PyTorch 2.12 + transformers 4.51.3:

- [x] Reproduced #392: the bundled presets fail to load under `weights_only=True` + `safe_globals` with the exact `SETITEMS` error.
- [x] All 25 bundled `demo/voices/streaming_model/*.pt` files load via `load_voice_preset`, byte-identical (`torch.equal` on every `last_hidden_state` and every cache key/value tensor) to a trusted full unpickle.
- [x] Security: a `.pt` whose payload calls `os.system` is rejected with `UnpicklingError` in both the zip and legacy formats, and the side effect never runs.
- [x] Downstream attribute access (`outputs.past_key_values`, `outputs.last_hidden_state`) and item access (`outputs["last_hidden_state"]`) keep working.

Closes #392
