### PR TITLE
docs: avoid editable install failures

### DIFF
--- a/docs/vibevoice-asr.md
+++ b/docs/vibevoice-asr.md
@@ -70,6 +70,7 @@ sudo docker run --privileged --net=host --ipc=host --ulimit memlock=-1:-1 --ulim
 git clone https://github.com/microsoft/VibeVoice.git
 cd VibeVoice
 
+python -m pip install --upgrade pip setuptools
 pip install -e .
 ```
 
@@ -129,6 +130,5 @@ LoRA (Low-Rank Adaptation) fine-tuning is supported. See [Finetuning](../finetun
 ## 📄 License
 
 This project is licensed under the [MIT License](../LICENSE).
-
 
 

--- a/docs/vibevoice-realtime-0.5b.md
+++ b/docs/vibevoice-realtime-0.5b.md
@@ -97,7 +97,8 @@ sudo docker run --privileged --net=host --ipc=host --ulimit memlock=-1:-1 --ulim
 git clone https://github.com/microsoft/VibeVoice.git
 cd VibeVoice/
 
-pip install -e .[streamingtts]
+python -m pip install --upgrade pip setuptools
+pip install -e '.[streamingtts]'
 ```
 
 

--- a/finetuning-asr/README.md
+++ b/finetuning-asr/README.md
@@ -6,6 +6,7 @@ This directory contains scripts for LoRA (Low-Rank Adaptation) fine-tuning of th
 
 ```bash
 # Install vibevoice first
+python -m pip install --upgrade pip setuptools
 pip install -e .
 
 pip install peft

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=64.0"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
## Summary
- document upgrading pip and setuptools before editable installs
- apply the same install step to ASR, realtime, and finetuning docs
- require setuptools >=64 in the build system so modern editable installs use a PEP 660-capable backend

Closes #402

## Verification
- git diff --check