### PR TITLE
fix(asr): derive speech token compression ratio from encoder config

### DIFF
--- a/tests/test_vibevoice_asr_processor.py
+++ b/tests/test_vibevoice_asr_processor.py
@@ -1,0 +1,57 @@
+import json
+import math
+
+from vibevoice.processor.vibevoice_asr_processor import (
+    _resolve_speech_tok_compress_ratio,
+)
+
+
+def test_asr_processor_derives_compression_ratio_from_encoder_ratios(tmp_path):
+    model_config_path = tmp_path / "config.json"
+    processor_config_path = tmp_path / "preprocessor_config.json"
+
+    model_config_path.write_text(
+        json.dumps(
+            {
+                "acoustic_tokenizer_config": {
+                    "encoder_ratios": [8, 5, 5, 4, 2, 2],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    processor_config_path.write_text(
+        json.dumps({"speech_tok_compress_ratio": 320}),
+        encoding="utf-8",
+    )
+
+    model_config = json.loads(model_config_path.read_text(encoding="utf-8"))
+    processor_config = json.loads(
+        processor_config_path.read_text(encoding="utf-8")
+    )
+
+    expected_ratio = math.prod(
+        model_config["acoustic_tokenizer_config"]["encoder_ratios"]
+    )
+
+    effective_ratio = _resolve_speech_tok_compress_ratio(
+        processor_config,
+        model_config,
+    )
+
+    # The processor should derive the compression ratio from the model
+    # configuration rather than using a stale value from
+    # preprocessor_config.json.
+    assert effective_ratio == expected_ratio
+
+    audio_samples = 34 * 60 * 24000
+
+    expected_tokens = math.ceil(audio_samples / expected_ratio)
+    stale_tokens = math.ceil(
+        audio_samples / processor_config["speech_tok_compress_ratio"]
+    )
+
+    assert math.ceil(audio_samples / effective_ratio) == expected_tokens
+    assert stale_tokens > expected_tokens
+    assert stale_tokens == expected_tokens * 10

--- a/vibevoice/processor/vibevoice_asr_processor.py
+++ b/vibevoice/processor/vibevoice_asr_processor.py
@@ -27,6 +27,25 @@ logger = logging.get_logger(__name__)
 SYSTEM_PROMPT = "You are a helpful assistant that transcribes audio input into text output in JSON format."
 
 
+def _get_model_speech_tok_compress_ratio(model_config: Dict[str, Any]) -> Optional[int]:
+    acoustic_config = model_config.get("acoustic_tokenizer_config", {})
+    encoder_ratios = acoustic_config.get("encoder_ratios")
+    if not encoder_ratios:
+        return None
+    return math.prod(int(ratio) for ratio in encoder_ratios)
+
+
+def _resolve_speech_tok_compress_ratio(
+    processor_config: Dict[str, Any],
+    model_config: Dict[str, Any],
+    default: int = 3200,
+) -> int:
+    model_speech_tok_compress_ratio = _get_model_speech_tok_compress_ratio(model_config)
+    if model_speech_tok_compress_ratio is not None:
+        return model_speech_tok_compress_ratio
+    return int(processor_config.get("speech_tok_compress_ratio", default))
+
+
 class VibeVoiceASRProcessor: 
     """
     Processor for VibeVoice ASR (Automatic Speech Recognition) models.
@@ -109,9 +128,17 @@ class VibeVoiceASRProcessor:
         from transformers.utils import cached_file
         from vibevoice.modular.modular_vibevoice_text_tokenizer import VibeVoiceASRTextTokenizerFast
         
-        # Try to load configuration
+        # Try to load processor and model configuration. The ASR prompt must
+        # reserve one speech placeholder per audio-tokenizer frame, so prefer
+        # the tokenizer stride from the model config when it is available.
         config_path = os.path.join(pretrained_model_name_or_path, "preprocessor_config.json")
         config = {}
+        model_config = {}
+        cached_file_kwargs = {
+            key: value
+            for key, value in kwargs.items()
+            if key not in {"language_model_pretrained_name"}
+        }
         
         if os.path.exists(config_path):
             with open(config_path, 'r') as f:
@@ -121,16 +148,32 @@ class VibeVoiceASRProcessor:
                 config_file = cached_file(
                     pretrained_model_name_or_path,
                     "preprocessor_config.json",
-                    **kwargs
+                    **cached_file_kwargs
                 )
                 with open(config_file, 'r') as f:
                     config = json.load(f)
             except Exception as e:
                 logger.warning(f"Could not load preprocessor_config.json: {e}")
                 logger.warning("Using default configuration")
-        
+
+        model_config_path = os.path.join(pretrained_model_name_or_path, "config.json")
+        if os.path.exists(model_config_path):
+            with open(model_config_path, 'r') as f:
+                model_config = json.load(f)
+        else:
+            try:
+                model_config_file = cached_file(
+                    pretrained_model_name_or_path,
+                    "config.json",
+                    **cached_file_kwargs
+                )
+                with open(model_config_file, 'r') as f:
+                    model_config = json.load(f)
+            except Exception as e:
+                logger.warning(f"Could not load config.json: {e}")
+
         # Extract parameters
-        speech_tok_compress_ratio = config.get("speech_tok_compress_ratio", 3200)
+        speech_tok_compress_ratio = _resolve_speech_tok_compress_ratio(config, model_config)
         target_sample_rate = config.get("target_sample_rate", 24000)
         normalize_audio = config.get("normalize_audio", True)
         


### PR DESCRIPTION
## Summary

This PR addresses Issue #332 by deriving the ASR speech token compression ratio from the model's encoder configuration (`acoustic_tokenizer_config.encoder_ratios`) instead of relying solely on `preprocessor_config.json`.

When available, the processor now computes the effective compression ratio directly from the encoder configuration while preserving the previous behavior as a fallback for checkpoints that do not expose encoder ratios.

## Motivation

Issue #332 reports that long audio can generate approximately 153k speech placeholder tokens, exceeding the model context limit (131072) and eventually leading to a tensor dimension mismatch during ASR inference.

From investigating the processor and model configuration, the placeholder count can become inconsistent if `speech_tok_compress_ratio` differs from the encoder's effective stride.

Deriving the ratio from the encoder configuration keeps placeholder generation aligned with the encoder output while maintaining backward compatibility through the existing fallback behavior.

## Changes

- Derive `speech_tok_compress_ratio` from `acoustic_tokenizer_config.encoder_ratios` when available.
- Preserve the previous fallback behavior if encoder ratios are unavailable.
- Add a regression test covering compression-ratio resolution.

## Validation

- Added a regression test (`tests/test_vibevoice_asr_processor.py`).
- Regression test passes locally.
- Verified that the derived compression ratio matches the encoder stride defined by the model configuration.