### PR TITLE
fix: declare supported vLLM installation extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,9 @@ dependencies = [
 streamingtts = [
   "transformers==4.51.3", 
 ]
+vllm = [
+  "vllm==0.14.1",
+]
 
 [project.entry-points."vllm.general_plugins"]
 vibevoice = "vllm_plugin:register_vibevoice"

--- a/tests/test_packaging_contract.py
+++ b/tests/test_packaging_contract.py
@@ -1,0 +1,21 @@
+"""Keep the documented vLLM installation path aligned with package metadata."""
+
+from pathlib import Path
+import tomllib
+
+
+ROOT = Path(__file__).parents[1]
+
+
+def test_vllm_extra_pins_the_supported_runtime() -> None:
+    metadata = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+
+    assert metadata["project"]["optional-dependencies"]["vllm"] == ["vllm==0.14.1"]
+
+
+def test_vllm_launcher_installs_the_declared_extra() -> None:
+    launcher = (ROOT / "vllm_plugin" / "scripts" / "start_server.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert '"-e", "/app[vllm]"' in launcher


### PR DESCRIPTION
## Summary
- declare the `vllm` optional dependency used by `vllm_plugin/scripts/start_server.py`
- pin the extra to the vLLM 0.14.1 runtime documented by issue #231
- add a CPU-only packaging contract test that checks the built metadata and launcher entrypoint

## Validation
- `/usr/local/bin/python3 -m pytest tests/test_packaging_contract.py -q`
- `/usr/local/bin/python3 -m pip wheel . --no-deps --no-build-isolation -w /tmp/vibevoice-wheel-new`
- wheel metadata contains `Provides-Extra: vllm` and `Requires-Dist: vllm==0.14.1; extra == "vllm"`
- `git diff --check`

Related to #231. This is limited to the packaging/install contract; vLLM API compatibility remains covered separately.