### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,4 +206,4 @@ We do not recommend using VibeVoice in commercial or real-world applications wit
 
 ## Star History
 
-![Star History Chart](https://api.star-history.com/svg?repos=Microsoft/vibevoice&type=date&legend=top-left)
+![Star History Chart](https://star-history.dera.page/svg?repos=Microsoft/vibevoice&type=date&legend=top-left)


### PR DESCRIPTION
The star history chart in the README is currently broken because it relies on the GitHub stargazer API, which is no longer reliably accessible. This switches the chart to an alternative service that uses a different data source and requires no API token, so the chart renders again. No badges or other endpoints are affected.