### PR TITLE
Fix device mismatch in VibeVoiceASR.encode_speech under device_map=auto

### DIFF
--- a/vibevoice/modular/modeling_vibevoice_asr.py
+++ b/vibevoice/modular/modeling_vibevoice_asr.py
@@ -332,6 +332,11 @@ class VibeVoiceASRForConditionalGeneration(VibeVoiceASRPreTrainedModel, Generati
             
             # Combine acoustic and semantic features
             if speech_masks is not None:
+                # Under device_map="auto", acoustic_connector/semantic_connector can be
+                # dispatched to a different device than speech_masks (e.g. multi-GPU
+                # pipeline parallelism), and boolean-indexing requires the mask to be
+                # on the same device as the indexed tensor.
+                speech_masks = speech_masks.to(acoustic_features.device)
                 combined_features = acoustic_features[speech_masks] + semantic_features[speech_masks]
             else:
                 combined_features = acoustic_features + semantic_features


### PR DESCRIPTION
## Summary
- Fixes #240: running `microsoft/VibeVoice-ASR` with `device_map="auto"` across multiple GPUs crashes with:
  ```
  RuntimeError: indices should be either on cpu or on the same device as the indexed tensor (cuda:6)
  ```
  at `vibevoice/modular/modeling_vibevoice_asr.py:335`, inside `encode_speech`:
  ```python
  combined_features = acoustic_features[speech_masks] + semantic_features[speech_masks]
  ```
- Root cause: under `device_map="auto"`, `self.model.acoustic_connector`/`semantic_connector` can be dispatched (via `accelerate`) to a different GPU than wherever `speech_masks` was created, and PyTorch requires a boolean index tensor to be on CPU or on the same device as the tensor it indexes.
- This is the same class of multi-GPU device mismatch already handled elsewhere in this exact file — `forward()` does `shift_labels = shift_labels.to(shift_logits.device)` a few dozen lines below for the same reason. This PR applies the identical, already-established pattern to `speech_masks`.

## Change
- `speech_masks = speech_masks.to(acoustic_features.device)` right before the boolean-indexed combine, in `VibeVoiceASRForConditionalGeneration.encode_speech`.

## Test plan
- [x] `python3 -m py_compile vibevoice/modular/modeling_vibevoice_asr.py`
- [x] Verified the change is a safe no-op for the common single-device case: with `speech_masks`/`acoustic_features`/`semantic_features` all on the same device, the output is bit-identical (`torch.equal`) to the pre-change code path.
- [ ] I don't have multi-GPU hardware available to reproduce the exact `device_map="auto"` cross-GPU scenario from the issue end-to-end — would appreciate confirmation from the reporter or a maintainer with multi-GPU access that this resolves it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016fM2LafALmBK16KnFWjsp7